### PR TITLE
EWDK support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,24 @@ Please read the [Code of Conduct](CODE_OF_CONDUCT.md).
 * Run the tests: `rad test`.
 * Check out `rad --help` for more information. 😎 🎉
 
+### Windows
+
+If you're working on ARM64 Windows, you should use the Bazel binary directly.
+There is a [bug in bazilisk](https://github.com/bazelbuild/bazelisk/issues/572)
+that ends up using the x64 version on Bazel on ARM64 systems. To work around
+this it is recommended to use the Bazel binary directly.
+
+Building with a normal Visual Studio install is possible, but
+[Bazel has bugs](https://github.com/bazelbuild/bazel/issues/22164) in their
+default toolchain resolution that may cause issues when cross compiling
+architectures. To work around this we recommend using the
+[EWDK toolchain](https://github.com/0xf005ba11/bazel_ewdk_cc/) instead. It is
+already configured as a bzlmod developer dependency for the project.
+
+1. Download and [Windows EWDK][microsoft.ewdk] and mount the ISO.
+2. Set `EWDKDIR` environment variable to the EWDK directory.
+3. You're all set! You might have to `rad clean --expunge`.
+
 ## Pull Requests
 
 * After opening a pull request you will be required to sign the
@@ -59,3 +77,4 @@ Please read the [Code of Conduct](CODE_OF_CONDUCT.md).
 [bazel.install]: https://docs.bazel.build/versions/main/install.html
 [bazel.bazelisk]: https://bazel.build/install/bazelisk
 [python.install]: https://www.python.org/downloads/
+[microsoft.ewdk]: https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk#download-icon-for-ewdk-enterprise-wdk-ewdk

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,3 +27,11 @@ git_override(
     remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
     commit = "a14ad3a64e7bf398ab48105aaa0348e032ac87f8",
 )
+
+# Windows - allows building with the EWDK, must set EWDKDIR environment variable
+bazel_dep(name = "ewdk_cc_toolchain", dev_dependency = True)
+git_override(
+    module_name = "ewdk_cc_toolchain",
+    remote = "https://github.com/0xf005ba11/bazel_ewdk_cc.git",
+    commit = "9b9b721f9bb73794bd376b8235a2decc6dea827c",
+)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "275108e4d79dafea614d4d2ebe0a1f5bd2f49d8465e91bd5f5b9cb7cd268de5c",
+  "moduleFileHash": "a020535d78fd3f4c6ccdd51d294c1f53f629fc96f78e1a452f5291568a0f7613",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -28,6 +28,7 @@
         "googletest": "googletest@1.14.0",
         "google_benchmark": "google_benchmark@1.8.3",
         "hedron_compile_commands": "hedron_compile_commands@_",
+        "ewdk_cc_toolchain": "ewdk_cc_toolchain@_",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       }
@@ -42,7 +43,7 @@
       "extensionUsages": [],
       "deps": {
         "com_google_absl": "abseil-cpp@20230125.1",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -73,7 +74,7 @@
       "extensionUsages": [],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.4.1",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "rules_foreign_cc": "rules_foreign_cc@0.9.0",
         "rules_cc": "rules_cc@0.0.9",
         "libpfm": "libpfm@4.11.0",
@@ -164,6 +165,41 @@
         }
       ],
       "deps": {
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      }
+    },
+    "ewdk_cc_toolchain@_": {
+      "name": "ewdk_cc_toolchain",
+      "version": "1.0.11",
+      "key": "ewdk_cc_toolchain@_",
+      "repoName": "ewdk_cc_toolchain",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [
+        "@ewdk_toolchains//:all"
+      ],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@ewdk_cc_toolchain//:ewdk_extension.bzl",
+          "extensionName": "toolchains",
+          "usingModule": "ewdk_cc_toolchain@_",
+          "location": {
+            "file": "@@ewdk_cc_toolchain~//:MODULE.bazel",
+            "line": 13,
+            "column": 27
+          },
+          "imports": {
+            "ewdk_toolchains": "ewdk_toolchains"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "rules_cc": "rules_cc@0.0.9",
+        "platforms": "platforms@0.0.10",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       }
@@ -313,7 +349,7 @@
         "rules_proto": "rules_proto@5.3.0-21.7",
         "rules_python": "rules_python@0.22.1",
         "buildozer": "buildozer@6.4.0.2",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "com_google_protobuf": "protobuf@21.7",
         "zlib": "zlib@1.3",
         "build_bazel_apple_support": "apple_support@1.5.0",
@@ -329,7 +365,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "bazel_tools": "bazel_tools@_"
       }
     },
@@ -343,7 +379,7 @@
       "extensionUsages": [],
       "deps": {
         "rules_cc": "rules_cc@0.0.9",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "bazel_skylib": "bazel_skylib@1.4.1",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -364,14 +400,32 @@
         }
       }
     },
-    "platforms@0.0.7": {
+    "platforms@0.0.10": {
       "name": "platforms",
-      "version": "0.0.7",
-      "key": "platforms@0.0.7",
+      "version": "0.0.10",
+      "key": "platforms@0.0.10",
       "repoName": "platforms",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [],
-      "extensionUsages": [],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@platforms//host:extension.bzl",
+          "extensionName": "host_platform",
+          "usingModule": "platforms@0.0.10",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel",
+            "line": 9,
+            "column": 30
+          },
+          "imports": {
+            "host_platform": "host_platform"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
       "deps": {
         "rules_license": "rules_license@0.0.7",
         "bazel_tools": "bazel_tools@_",
@@ -382,9 +436,9 @@
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz"
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"
           ],
-          "integrity": "sha256-OlYcmee9vpFzqmU/1Xn+hJ8djWc5V4CrR3Cx84FDHVE=",
+          "integrity": "sha256-IY7+juc20mo1cmY7N0olPAErcW2K8MB+hC6C8jigp+4=",
           "strip_prefix": "",
           "remote_patches": {},
           "remote_patch_strip": 0
@@ -420,7 +474,7 @@
         }
       ],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -452,7 +506,7 @@
       ],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -518,7 +572,7 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.4.1",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -548,7 +602,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "rules_foreign_cc": "rules_foreign_cc@0.9.0",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -648,7 +702,7 @@
         }
       ],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_skylib": "bazel_skylib@1.4.1",
         "rules_proto": "rules_proto@5.3.0-21.7",
@@ -810,7 +864,7 @@
         }
       ],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "bazel_skylib": "bazel_skylib@1.4.1",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "com_google_protobuf": "protobuf@21.7",
@@ -992,7 +1046,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -1045,7 +1099,7 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.4.1",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -1107,7 +1161,7 @@
         "rules_proto": "rules_proto@5.3.0-21.7",
         "com_google_protobuf": "protobuf@21.7",
         "com_google_absl": "abseil-cpp@20230125.1",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.10",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -1351,6 +1405,28 @@
           }
         },
         "recordedRepoMappingEntries": []
+      }
+    },
+    "@@ewdk_cc_toolchain~//:ewdk_extension.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "o8jWc/DKL6u/xdGVR7ZVOsdvrJWHczkHwS5vnpdr1b8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "ewdk_toolchains": {
+            "bzlFile": "@@ewdk_cc_toolchain~//:ewdk_cc_configure.bzl",
+            "ruleClassName": "ewdk_cc_autoconf_toolchains",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "ewdk_cc_toolchain~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@rules_foreign_cc~//foreign_cc:extensions.bzl%ext": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "a020535d78fd3f4c6ccdd51d294c1f53f629fc96f78e1a452f5291568a0f7613",
+  "moduleFileHash": "f4948b1db3c8426ce61c4e3b27033e236b6dbb6d042cab34daf9aa917ae9f808",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"

--- a/tools/rad/rad/repo.py
+++ b/tools/rad/rad/repo.py
@@ -17,5 +17,23 @@
 """Utility functions to interact with the Radiant repository."""
 
 import pathlib
+import platform
+
+
+def _norm_machine():
+    """Normalizes the machine architecture to a common name."""
+    machine = platform.machine().lower()
+    if machine in ["x86", "i386", "i686"]:
+        return "x86"
+    if machine in ["x64", "x86_64", "amd64"]:
+        return "x64"
+    if machine in ["arm64", "aarch64", "aarch64_be", "armv8b", "armv8l"]:
+        return "arm64"
+    if machine in ["arm", "armv7l"]:
+        return "arm"
+    return "unknown"
+
 
 ROOT_PATH = pathlib.Path(__file__).resolve().parents[3]
+NORM_ARCH = _norm_machine()
+NORM_ARCHES = ["x64", "x86", "arm64", "arm"]


### PR DESCRIPTION
Re-introduces the ability to compile using the EWDK. This is a necessary workaround for https://github.com/archonitelabs/radiant-cpp/issues/7. Also cleans up the rad tooling arguments around cross compiling.

Until Bazel resolves the platform constraint toolchain resolution for Windows (https://github.com/bazelbuild/bazel/issues/22164). The recommendation for developers looking to cross compile on Windows is to use the EWDK as outlined `CONTRIBUTING.md`. Also, as noted, when working on Windows ARM64 machine developers should use the specific Bazel binary instead of using bazelisk (until https://github.com/bazelbuild/bazelisk/issues/572 is resolved).