### PR TITLE
correct arm64 for gcc

### DIFF
--- a/radiant/TotallyRad.h
+++ b/radiant/TotallyRad.h
@@ -138,7 +138,7 @@ static_assert(!(RAD_WINDOWS && RAD_MACOS), "env invalid os");
 #define RAD_I386  1
 #define RAD_ARM64 0
 #define RAD_ARM   0
-#elif defined(_M_ARM64) || defined(__arm64__)
+#elif defined(_M_ARM64) || defined(__aarch64__)
 #define RAD_AMD64 0
 #define RAD_I386  0
 #define RAD_ARM64 1


### PR DESCRIPTION
ARM64 detection for GCC was not defined correctly, this caused caused an unsupported architecture error when that is not the case.