### PR TITLE
fix pre-commit pylint when in venv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        entry: pylint
+        entry: python -m pylint
         language: system
         types: [python]
         require_serial: true


### PR DESCRIPTION
fixes pre-commit hook for pylint to make it work from within a python virtual environment