### PR TITLE
fix SharedPtr block destruction

### DIFF
--- a/test/TestAlloc.cpp
+++ b/test/TestAlloc.cpp
@@ -19,48 +19,98 @@
 namespace radtest
 {
 
-uint32_t StaticCountingAllocatorImpl::freeCount = 0;
-uint32_t StaticCountingAllocatorImpl::allocCount = 0;
-uint32_t StaticCountingAllocatorImpl::reallocCount = 0;
-uint32_t StaticCountingAllocatorImpl::freeBytesCount = 0;
-uint32_t StaticCountingAllocatorImpl::allocBytesCount = 0;
-uint32_t StaticCountingAllocatorImpl::reallocBytesCount = 0;
+uint32_t CountingAllocatorImpl::g_FreeCount = 0;
+uint32_t CountingAllocatorImpl::g_AllocCount = 0;
+uint32_t CountingAllocatorImpl::g_ReallocCount = 0;
+uint32_t CountingAllocatorImpl::g_FreeBytesCount = 0;
+uint32_t CountingAllocatorImpl::g_AllocBytesCount = 0;
+uint32_t CountingAllocatorImpl::g_ReallocBytesCount = 0;
 
-void StaticCountingAllocatorImpl::Free(void* ptr) noexcept
+void CountingAllocatorImpl::Free(void* ptr) noexcept
 {
-    ++freeCount;
+    ++g_FreeCount;
     free(ptr);
 }
 
-void* StaticCountingAllocatorImpl::Alloc(uint32_t size) noexcept
+void* CountingAllocatorImpl::Alloc(uint32_t size) noexcept
 {
-    ++allocCount;
+    ++g_AllocCount;
     return malloc(size);
 }
 
-void* StaticCountingAllocatorImpl::Realloc(void* ptr, uint32_t size) noexcept
+void* CountingAllocatorImpl::Realloc(void* ptr, uint32_t size) noexcept
 {
-    ++reallocCount;
+    ++g_ReallocCount;
     return realloc(ptr, size);
 }
 
-void StaticCountingAllocatorImpl::FreeBytes(void* ptr) noexcept
+void CountingAllocatorImpl::FreeBytes(void* ptr) noexcept
 {
-    ++freeBytesCount;
+    ++g_FreeBytesCount;
     free(ptr);
 }
 
-void* StaticCountingAllocatorImpl::AllocBytes(uint32_t size) noexcept
+void* CountingAllocatorImpl::AllocBytes(uint32_t size) noexcept
 {
-    ++allocBytesCount;
+    ++g_AllocBytesCount;
     return malloc(size);
 }
 
-void* StaticCountingAllocatorImpl::ReallocBytes(void* ptr,
-                                                uint32_t size) noexcept
+void* CountingAllocatorImpl::ReallocBytes(void* ptr, uint32_t size) noexcept
 {
-    ++reallocBytesCount;
+    ++g_ReallocBytesCount;
     return realloc(ptr, size);
+}
+
+uint32_t CountingAllocatorImpl::FreeCount() noexcept
+{
+    return g_FreeCount;
+}
+
+uint32_t CountingAllocatorImpl::AllocCount() noexcept
+{
+    return g_AllocCount;
+}
+
+uint32_t CountingAllocatorImpl::ReallocCount() noexcept
+{
+    return g_ReallocCount;
+}
+
+uint32_t CountingAllocatorImpl::FreeBytesCount() noexcept
+{
+    return g_FreeBytesCount;
+}
+
+uint32_t CountingAllocatorImpl::AllocBytesCount() noexcept
+{
+    return g_AllocBytesCount;
+}
+
+uint32_t CountingAllocatorImpl::ReallocBytesCount() noexcept
+{
+    return g_ReallocBytesCount;
+}
+
+void CountingAllocatorImpl::ResetCounts() noexcept
+{
+    g_FreeCount = 0;
+    g_AllocCount = 0;
+    g_ReallocCount = 0;
+    g_FreeBytesCount = 0;
+    g_AllocBytesCount = 0;
+    g_ReallocBytesCount = 0;
+}
+
+bool CountingAllocatorImpl::VerifyCounts() noexcept
+{
+    return (g_AllocCount == g_FreeCount);
+}
+
+bool CountingAllocatorImpl::VerifyCounts(uint32_t expectedAllocs,
+                                         uint32_t expectedFrees) noexcept
+{
+    return (g_AllocCount == expectedAllocs) && (g_FreeCount == expectedFrees);
 }
 
 } // namespace radtest

--- a/test/test_SharedPtr.cpp
+++ b/test/test_SharedPtr.cpp
@@ -268,7 +268,7 @@ TEST(TestSharedPtr, ReleaseDestruct)
 TEST(TestSharedPtr, ReleaseFree)
 {
     using PtrBlock =
-        rad::detail::_PtrBlock<int, radtest::StaticCountingAllocator<int>>;
+        rad::detail::_PtrBlock<int, radtest::StatefulCountingAllocator<int>>;
     PtrBlock::AllocatorType alloc;
     alloc.ResetCounts();
 
@@ -319,7 +319,7 @@ TEST(TestSharedPtr, AllocateSharedFail)
 
 TEST(TestSharedPtr, AllocateSharedThrows)
 {
-    radtest::StaticCountingAllocator<radtest::ThrowingObject> alloc;
+    radtest::StatefulCountingAllocator<radtest::ThrowingObject> alloc;
     alloc.ResetCounts();
 
     EXPECT_THROW(rad::AllocateShared<radtest::ThrowingObject>(alloc, 1),
@@ -487,7 +487,7 @@ TEST(TestSharedPtr, Swap)
 
 TEST(TestSharedPtr, SelfCopyAssign)
 {
-    radtest::StaticCountingAllocator<int> alloc;
+    radtest::StatefulCountingAllocator<int> alloc;
     alloc.ResetCounts();
 
     auto ptr = rad::AllocateShared<int>(alloc, 2);
@@ -501,7 +501,7 @@ TEST(TestSharedPtr, SelfCopyAssign)
 
 TEST(TestSharedPtr, CopyAssignNoReset)
 {
-    radtest::StaticCountingAllocator<int> alloc;
+    radtest::StatefulCountingAllocator<int> alloc;
     alloc.ResetCounts();
 
     auto ptr = rad::AllocateShared<int>(alloc, 2);
@@ -517,7 +517,7 @@ TEST(TestSharedPtr, CopyAssignNoReset)
 
 TEST(TestSharedPtr, CopyAssignReset)
 {
-    radtest::StaticCountingAllocator<int> alloc;
+    radtest::StatefulCountingAllocator<int> alloc;
     alloc.ResetCounts();
 
     auto ptr = rad::AllocateShared<int>(alloc, 2);
@@ -533,7 +533,7 @@ TEST(TestSharedPtr, CopyAssignReset)
 
 TEST(TestSharedPtr, CopyAssignNull)
 {
-    radtest::StaticCountingAllocator<int> alloc;
+    radtest::StatefulCountingAllocator<int> alloc;
     alloc.ResetCounts();
 
     auto ptr = rad::AllocateShared<int>(alloc, 2);
@@ -545,7 +545,7 @@ TEST(TestSharedPtr, CopyAssignNull)
 
 TEST(TestSharedPtr, SelfMoveAssign)
 {
-    radtest::StaticCountingAllocator<int> alloc;
+    radtest::StatefulCountingAllocator<int> alloc;
     alloc.ResetCounts();
 
     auto ptr = rad::AllocateShared<int>(alloc, 2);
@@ -559,7 +559,7 @@ TEST(TestSharedPtr, SelfMoveAssign)
 
 TEST(TestSharedPtr, MoveAssignNoReset)
 {
-    radtest::StaticCountingAllocator<int> alloc;
+    radtest::StatefulCountingAllocator<int> alloc;
     alloc.ResetCounts();
 
     auto ptr = rad::AllocateShared<int>(alloc, 2);
@@ -576,7 +576,7 @@ TEST(TestSharedPtr, MoveAssignNoReset)
 
 TEST(TestSharedPtr, MoveAssignReset)
 {
-    radtest::StaticCountingAllocator<int> alloc;
+    radtest::StatefulCountingAllocator<int> alloc;
     alloc.ResetCounts();
 
     auto ptr = rad::AllocateShared<int>(alloc, 2);
@@ -600,7 +600,7 @@ TEST(TestSharedPtr, PolymorphicCtor)
     EXPECT_EQ(static_cast<void*>(&d), static_cast<void*>(b));
     EXPECT_NE(static_cast<void*>(b), static_cast<void*>(e));
 
-    radtest::StaticCountingAllocator<sptestobjs::Derived> alloc;
+    radtest::StatefulCountingAllocator<sptestobjs::Derived> alloc;
     alloc.ResetCounts();
 
     {
@@ -622,7 +622,7 @@ TEST(TestSharedPtr, PolymorphicCtor)
 
 TEST(TestSharedPtr, PolymorphicAssign)
 {
-    radtest::StaticCountingAllocator<sptestobjs::Derived> alloc;
+    radtest::StatefulCountingAllocator<sptestobjs::Derived> alloc;
     alloc.ResetCounts();
 
     {
@@ -645,6 +645,22 @@ TEST(TestSharedPtr, PolymorphicAssign)
 
     EXPECT_EQ(alloc.AllocCount(), 1u);
     EXPECT_TRUE(alloc.VerifyCounts());
+}
+
+TEST(TestSharedPtr, StatefulAllocator)
+{
+    radtest::StatefulCountingAllocator<int> alloc;
+    alloc.ResetCounts();
+
+    auto ptr = rad::AllocateShared<int>(alloc, 2);
+    EXPECT_TRUE(ptr);
+    EXPECT_EQ(*ptr, 2);
+    EXPECT_EQ(alloc.AllocCount(), 1u);
+    EXPECT_EQ(alloc.FreeCount(), 0u);
+
+    ptr.Reset();
+    EXPECT_EQ(alloc.AllocCount(), 1u);
+    EXPECT_EQ(alloc.FreeCount(), 1u);
 }
 
 TEST(TestWeakPtr, ConstructEmpy)
@@ -822,7 +838,7 @@ TEST(TestWeakPtr, PolymorphicCtor)
     EXPECT_EQ(static_cast<void*>(&d), static_cast<void*>(b));
     EXPECT_NE(static_cast<void*>(b), static_cast<void*>(e));
 
-    radtest::StaticCountingAllocator<sptestobjs::Derived> alloc;
+    radtest::StatefulCountingAllocator<sptestobjs::Derived> alloc;
     alloc.ResetCounts();
 
     {
@@ -860,7 +876,7 @@ TEST(TestWeakPtr, PolymorphicCtor)
 
 TEST(TestWeakPtr, PolymorphicAssign)
 {
-    radtest::StaticCountingAllocator<sptestobjs::Derived> alloc;
+    radtest::StatefulCountingAllocator<sptestobjs::Derived> alloc;
     alloc.ResetCounts();
 
     {


### PR DESCRIPTION
SharedPtr was not correctly handling destruction of the block. The allocator would be destructed alongside the compressed pair when the strong reference went to zero. Then it would attempt to free using the allocator it just destructed. This is a problem for stateful allocators as it may have internal state that is rendered invalid after destruction.

The fix is to only destruct the managed object when the strong reference goes to zero. Then, when the weak reference goes to zero, take a copy of the allocator and destruct the remaining parts (including the internal allocator). Then use the copied allocator to carry out the free.