### PR TITLE
update ewdk toolchain, support native ARM64 compile

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,5 +33,5 @@ bazel_dep(name = "ewdk_cc_toolchain", dev_dependency = True)
 git_override(
     module_name = "ewdk_cc_toolchain",
     remote = "https://github.com/0xf005ba11/bazel_ewdk_cc.git",
-    commit = "9b9b721f9bb73794bd376b8235a2decc6dea827c",
+    commit = "e13b2fddcd46096b2ca92d13b1d5e1e48cccfc43",
 )


### PR DESCRIPTION
Upgrades EWDK toolchain to pick up: https://github.com/0xf005ba11/bazel_ewdk_cc/pull/3