### PR TITLE
remove reserved namespace pollution

### DIFF
--- a/default_copts.bzl
+++ b/default_copts.bzl
@@ -18,7 +18,7 @@ RAD_CPP20 = select({
     "//:clang": ["-std=c++20"],
 })
 
-_RAD_GCC_OPTS = [
+RAD_GCC_OPTS = [
     "-Wall",
     "-Wextra",
     "-Wcast-qual",
@@ -44,6 +44,6 @@ RAD_DEFAULT_COPTS = select({
         "/DNOMINMAX",
         "/Zc:__cplusplus",
     ],
-    "//:gcc": _RAD_GCC_OPTS,
-    "//:clang": _RAD_GCC_OPTS,
+    "//:gcc": RAD_GCC_OPTS,
+    "//:clang": RAD_GCC_OPTS,
 })

--- a/radiant/Atomic.h
+++ b/radiant/Atomic.h
@@ -30,11 +30,11 @@ RAD_INLINE_VAR constexpr detail::atomic::AcqRelTag MemOrderAcqRel{};
 RAD_INLINE_VAR constexpr detail::atomic::SeqCstTag MemOrderSeqCst{};
 
 #if RAD_REQUIRE_EXPLICIT_ATOMIC_ORDERING
-#define _RAD_ATOMIC_MEMORDER_T typename Order
-#define _RAD_ATOMIC_MEMORDER_P MemoryOrderTag<Order>
+#define RAD_ATOMIC_MEMORDER_T typename Order
+#define RAD_ATOMIC_MEMORDER_P MemoryOrderTag<Order>
 #else
-#define _RAD_ATOMIC_MEMORDER_T typename Order = detail::atomic::SeqCstTag
-#define _RAD_ATOMIC_MEMORDER_P MemoryOrderTag<Order> = MemoryOrderTag<Order>()
+#define RAD_ATOMIC_MEMORDER_T typename Order = detail::atomic::SeqCstTag
+#define RAD_ATOMIC_MEMORDER_P MemoryOrderTag<Order> = MemoryOrderTag<Order>()
 #endif
 
 namespace detail
@@ -62,20 +62,20 @@ public:
 
     RAD_NOT_COPYABLE(AtomicIntegral);
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    void Store(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    void Store(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         SelectIntrinsic<T>::Store(m_val, val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T Load(_RAD_ATOMIC_MEMORDER_P) const noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T Load(RAD_ATOMIC_MEMORDER_P) const noexcept
     {
         return SelectIntrinsic<T>::Load(m_val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T Exchange(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T Exchange(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::Exchange(m_val, val, Order());
     }
@@ -93,10 +93,10 @@ public:
                                                        Failure());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
+    template <RAD_ATOMIC_MEMORDER_T>
     bool CompareExchangeWeak(T& expected,
                              T desired,
-                             _RAD_ATOMIC_MEMORDER_P) noexcept
+                             RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return CompareExchangeWeak<Order, Order>(expected,
                                                  desired,
@@ -117,40 +117,40 @@ public:
                                                          Failure());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
+    template <RAD_ATOMIC_MEMORDER_T>
     bool CompareExchangeStrong(T& expected,
                                T desired,
-                               _RAD_ATOMIC_MEMORDER_P) noexcept
+                               RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return CompareExchangeStrong(expected, desired, Order(), Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T FetchAdd(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T FetchAdd(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::FetchAdd(m_val, val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T FetchSub(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T FetchSub(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::FetchSub(m_val, val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T FetchAnd(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T FetchAnd(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::FetchAnd(m_val, val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T FetchOr(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T FetchOr(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::FetchOr(m_val, val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T FetchXor(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T FetchXor(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::FetchXor(m_val, val, Order());
     }
@@ -238,20 +238,20 @@ public:
 
     RAD_NOT_COPYABLE(AtomicPointer);
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    void Store(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    void Store(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         SelectIntrinsic<T>::Store(m_val, val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T Load(_RAD_ATOMIC_MEMORDER_P) const noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T Load(RAD_ATOMIC_MEMORDER_P) const noexcept
     {
         return SelectIntrinsic<T>::Load(m_val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T Exchange(T val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T Exchange(T val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::Exchange(m_val, val, Order());
     }
@@ -269,10 +269,10 @@ public:
                                                        Failure());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
+    template <RAD_ATOMIC_MEMORDER_T>
     bool CompareExchangeWeak(T& expected,
                              T desired,
-                             _RAD_ATOMIC_MEMORDER_P) noexcept
+                             RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return CompareExchangeWeak<Order, Order>(expected,
                                                  desired,
@@ -293,22 +293,22 @@ public:
                                                          Failure());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
+    template <RAD_ATOMIC_MEMORDER_T>
     bool CompareExchangeStrong(T& expected,
                                T desired,
-                               _RAD_ATOMIC_MEMORDER_P) noexcept
+                               RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return CompareExchangeStrong(expected, desired, Order(), Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T FetchAdd(ptrdiff_t val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T FetchAdd(ptrdiff_t val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::FetchAdd(m_val, val, Order());
     }
 
-    template <_RAD_ATOMIC_MEMORDER_T>
-    T FetchSub(ptrdiff_t val, _RAD_ATOMIC_MEMORDER_P) noexcept
+    template <RAD_ATOMIC_MEMORDER_T>
+    T FetchSub(ptrdiff_t val, RAD_ATOMIC_MEMORDER_P) noexcept
     {
         return SelectIntrinsic<T>::FetchSub(m_val, val, Order());
     }

--- a/radiant/Memory.h
+++ b/radiant/Memory.h
@@ -22,11 +22,11 @@
 // enforce verbosity if they wish.
 //
 #ifdef RAD_DEFAULT_ALLOCATOR
-#define _RAD_DEFAULT_ALLOCATOR(x)    RAD_DEFAULT_ALLOCATOR<x>
-#define _RAD_DEFAULT_ALLOCATOR_EQ(x) = RAD_DEFAULT_ALLOCATOR<x>
+#define RAD_ALLOCATOR(x)    RAD_DEFAULT_ALLOCATOR<x>
+#define RAD_ALLOCATOR_EQ(x) = RAD_DEFAULT_ALLOCATOR<x>
 #else
-#define _RAD_DEFAULT_ALLOCATOR(x)
-#define _RAD_DEFAULT_ALLOCATOR_EQ(x)
+#define RAD_ALLOCATOR(x)
+#define RAD_ALLOCATOR_EQ(x)
 #endif
 
 namespace rad

--- a/radiant/ScopeExit.h
+++ b/radiant/ScopeExit.h
@@ -122,7 +122,7 @@ ScopeGuard<Fn> MakeScopeGuard(Fn&& fn)
 
 } // namespace rad
 
-#define RAD_SCOPE_GUARD_NAME_STRINGIFY(suffix) __scopeGuard##suffix
+#define RAD_SCOPE_GUARD_NAME_STRINGIFY(suffix) scopeGuard##suffix
 #define RAD_SCOPE_GUARD_NAME(suffix)           RAD_SCOPE_GUARD_NAME_STRINGIFY(suffix)
 #define RAD_SCOPE_GUARD(fn)                                                    \
     const auto RAD_SCOPE_GUARD_NAME(__LINE__) = rad::MakeScopeGuard(fn)

--- a/radiant/TotallyRad.h
+++ b/radiant/TotallyRad.h
@@ -174,8 +174,8 @@ static_assert(!(RAD_WINDOWS && RAD_MACOS), "env invalid os");
 #define RAD_YIELD_PROCESSOR() sched_yield()
 #endif
 
-#define _RAD_CONCAT(x, y) x##y
-#define RAD_CONCAT(x, y)  _RAD_CONCAT(x, y)
+#define RAD_CONCAT_INNER(x, y) x##y
+#define RAD_CONCAT(x, y)       RAD_CONCAT_INNER(x, y)
 
 #if RAD_USER_MODE && RAD_DBG
 #include <assert.h>

--- a/radiant/TypeTraits.h
+++ b/radiant/TypeTraits.h
@@ -75,13 +75,13 @@ RAD_INLINE_VAR constexpr bool IsRRef = std::is_rvalue_reference<T>::value;
 namespace detail
 {
 template <typename T, typename U, bool = IsLRef<T> && !IsRRef<U>>
-struct _IsLRefBindable
+struct IsLRefBindable
 {
     static constexpr bool value = false;
 };
 
 template <typename T, typename U>
-struct _IsLRefBindable<T, U, true>
+struct IsLRefBindable<T, U, true>
 {
 private:
 
@@ -100,7 +100,7 @@ public:
 
 template <typename T, typename U>
 RAD_INLINE_VAR constexpr bool IsLRefBindable =
-    detail::_IsLRefBindable<T, U>::value;
+    detail::IsLRefBindable<T, U>::value;
 
 // std::decay not used here to avoid array-to-pointer/fn-to-pointer conversions
 // (based on a work-around by Luc Danton)
@@ -112,12 +112,12 @@ RAD_INLINE_VAR constexpr bool IsRelated = IsSame<
 namespace detail
 {
 template <typename... Types>
-struct _EnIfUnrelated : std::enable_if<true>
+struct EnIfUnrelated : std::enable_if<true>
 {
 };
 
 template <typename T, typename U, typename... Rest>
-struct _EnIfUnrelated<T, U, Rest...> : std::enable_if<!IsRelated<T, U>>
+struct EnIfUnrelated<T, U, Rest...> : std::enable_if<!IsRelated<T, U>>
 {
 };
 } // namespace detail
@@ -134,7 +134,7 @@ template <typename T>
 RAD_INLINE_VAR constexpr bool IsPointer = std::is_pointer<T>::value;
 
 template <typename... Types>
-using EnIfUnrelated = typename detail::_EnIfUnrelated<Types...>::type;
+using EnIfUnrelated = typename detail::EnIfUnrelated<Types...>::type;
 
 template <typename T, typename... TArgs>
 RAD_INLINE_VAR constexpr bool IsCtor =
@@ -232,13 +232,13 @@ RAD_INLINE_VAR constexpr bool IsNoThrowDtor =
 namespace detail
 {
 template <typename>
-RAD_INLINE_VAR constexpr bool _AlwaysFalse = false;
+RAD_INLINE_VAR constexpr bool AlwaysFalse = false;
 }
 
 template <typename T>
 typename std::add_rvalue_reference<T>::type DeclVal() noexcept
 {
-    RAD_S_ASSERTMSG(detail::_AlwaysFalse<T>, "Calling DeclVal is ill-formed");
+    RAD_S_ASSERTMSG(detail::AlwaysFalse<T>, "Calling DeclVal is ill-formed");
 }
 
 template <typename T>

--- a/radiant/Vector.h
+++ b/radiant/Vector.h
@@ -27,7 +27,7 @@ namespace rad
 /// @tparam TInlineCount Optionally specifies a number of elements for inline
 /// storage which may be used for small optimizations.
 template <typename T,
-          typename TAllocator _RAD_DEFAULT_ALLOCATOR_EQ(T),
+          typename TAllocator RAD_ALLOCATOR_EQ(T),
           uint16_t TInlineCount = 0>
 class Vector final
 {
@@ -493,7 +493,7 @@ constexpr uint16_t Vector<T, Allocator, TInlineCount>::InlineCount;
 /// @tparam TAllocator Allocator type to use.
 template <typename T,
           uint16_t TInlineCount,
-          typename TAllocator _RAD_DEFAULT_ALLOCATOR_EQ(T)>
+          typename TAllocator RAD_ALLOCATOR_EQ(T)>
 using InlineVector = Vector<T, TAllocator, TInlineCount>;
 
 template <typename T,

--- a/test/test_SharedPtr.cpp
+++ b/test/test_SharedPtr.cpp
@@ -24,8 +24,8 @@ namespace sptestobjs
 {
 // clang-format off
 using NoThrowAllocSp = rad::SharedPtr<int>;
-using NoThrowObjBlock = rad::detail::_PtrBlock<int, radtest::Allocator<int>>;
-using ThrowObjBlock = rad::detail::_PtrBlock<radtest::ThrowingObject, radtest::Allocator<radtest::ThrowingObject>>;
+using NoThrowObjBlock = rad::detail::PtrBlock<int, radtest::Allocator<int>>;
+using ThrowObjBlock = rad::detail::PtrBlock<radtest::ThrowingObject, radtest::Allocator<radtest::ThrowingObject>>;
 using NoThrowPair = NoThrowObjBlock::PairType;
 using ThrowPair = ThrowObjBlock::PairType;
 
@@ -33,11 +33,11 @@ using NoThrowObjSp = NoThrowAllocSp;
 using ThrowObjSp = rad::SharedPtr<radtest::ThrowingObject>;
 // clang-format on
 
-// _PtrBlock::PairType construction noexcept
+// PtrBlock::PairType construction noexcept
 RAD_S_ASSERT(noexcept(NoThrowPair(rad::DeclVal<NoThrowPair::FirstType&>(), 1)));
 RAD_S_ASSERT(!noexcept(ThrowPair(rad::DeclVal<ThrowPair::FirstType&>())));
 
-// _PtrBlock construction noexcept (EopPair constructor passthrough)
+// PtrBlock construction noexcept (EopPair constructor passthrough)
 RAD_S_ASSERT(noexcept(NoThrowObjBlock(NoThrowObjBlock::AllocatorType())));
 RAD_S_ASSERT(!noexcept(ThrowObjBlock(ThrowObjBlock::AllocatorType())));
 
@@ -110,14 +110,14 @@ void FreeTestBlock(sptestobjs::NoThrowObjBlock* block)
 
 TEST(TestSharedPtr, RefCountCtor)
 {
-    rad::detail::_PtrRefCount rc;
+    rad::detail::PtrRefCount rc;
     EXPECT_EQ(rc.StrongCount(), 1u);
     EXPECT_EQ(rc.WeakCount(), 1u);
 }
 
 TEST(TestSharedPtr, RefCountIncrement)
 {
-    rad::detail::_PtrRefCount rc;
+    rad::detail::PtrRefCount rc;
     rc.Increment();
     EXPECT_EQ(rc.StrongCount(), 2u);
     EXPECT_EQ(rc.WeakCount(), 1u);
@@ -125,7 +125,7 @@ TEST(TestSharedPtr, RefCountIncrement)
 
 TEST(TestSharedPtr, RefCountIncrementWeak)
 {
-    rad::detail::_PtrRefCount rc;
+    rad::detail::PtrRefCount rc;
     rc.IncrementWeak();
     EXPECT_EQ(rc.StrongCount(), 1u);
     EXPECT_EQ(rc.WeakCount(), 2u);
@@ -133,7 +133,7 @@ TEST(TestSharedPtr, RefCountIncrementWeak)
 
 TEST(TestSharedPtr, RefCountDrecment)
 {
-    rad::detail::_PtrRefCount rc;
+    rad::detail::PtrRefCount rc;
     rc.Increment();
     EXPECT_FALSE(rc.Decrement());
     EXPECT_EQ(rc.StrongCount(), 1u);
@@ -146,7 +146,7 @@ TEST(TestSharedPtr, RefCountDrecment)
 
 TEST(TestSharedPtr, RefCountDecrementWeak)
 {
-    rad::detail::_PtrRefCount rc;
+    rad::detail::PtrRefCount rc;
     rc.IncrementWeak();
     EXPECT_FALSE(rc.DecrementWeak());
     EXPECT_EQ(rc.StrongCount(), 1u);
@@ -159,7 +159,7 @@ TEST(TestSharedPtr, RefCountDecrementWeak)
 
 TEST(TestSharedPtr, RefCountLockWeak)
 {
-    rad::detail::_PtrRefCount rc;
+    rad::detail::PtrRefCount rc;
     EXPECT_TRUE(rc.LockWeak());
     EXPECT_EQ(rc.StrongCount(), 2u);
     EXPECT_EQ(rc.WeakCount(), 1u);
@@ -191,7 +191,7 @@ public:
 
 TEST(TestSharedPtr, RefCountLockWeakFailExchange)
 {
-    rad::detail::_TPtrRefCount<MockAtomic> rc;
+    rad::detail::TPtrRefCount<MockAtomic> rc;
 
     EXPECT_FALSE(rc.LockWeak());
     EXPECT_FALSE(rc.LockWeak());
@@ -201,13 +201,13 @@ TEST(TestSharedPtr, RefCountLockWeakFailExchange)
 
 TEST(TestSharedPtr, PtrBlockCtor)
 {
-    using PtrBlock = rad::detail::_PtrBlock<int, radtest::Allocator<int>>;
+    using PtrBlock = rad::detail::PtrBlock<int, radtest::Allocator<int>>;
     PtrBlock::AllocatorType alloc;
     PtrBlock block(alloc, 2);
     EXPECT_EQ(block.Value(), 2);
 
     using StatefulPtrBlock =
-        rad::detail::_PtrBlock<int, radtest::StatefulAllocator<int>>;
+        rad::detail::PtrBlock<int, radtest::StatefulAllocator<int>>;
     StatefulPtrBlock::AllocatorType statefulAlloc;
     StatefulPtrBlock statefulBlock(statefulAlloc, 4);
     RAD_S_ASSERT(sizeof(statefulBlock) >
@@ -252,9 +252,8 @@ TEST(TestSharedPtr, LockWeak)
 
 TEST(TestSharedPtr, ReleaseDestruct)
 {
-    using PtrBlock =
-        rad::detail::_PtrBlock<DestructCounter,
-                               radtest::Allocator<DestructCounter>>;
+    using PtrBlock = rad::detail::PtrBlock<DestructCounter,
+                                           radtest::Allocator<DestructCounter>>;
     PtrBlock::AllocatorType alloc;
     PtrBlock block(alloc);
     EXPECT_EQ(DestructCounter::counter, 0);
@@ -268,7 +267,7 @@ TEST(TestSharedPtr, ReleaseDestruct)
 TEST(TestSharedPtr, ReleaseFree)
 {
     using PtrBlock =
-        rad::detail::_PtrBlock<int, radtest::StatefulCountingAllocator<int>>;
+        rad::detail::PtrBlock<int, radtest::StatefulCountingAllocator<int>>;
     PtrBlock::AllocatorType alloc;
     alloc.ResetCounts();
 


### PR DESCRIPTION
Removes the use of `_` when prefixing things inside Radiant to avoid polluting or confusing with reserved/global namespaces.