### PR TITLE
allocator concept requirements

### DIFF
--- a/radiant/Memory.h
+++ b/radiant/Memory.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "radiant/TotallyRad.h"
+#include "radiant/TypeTraits.h"
 
 //
 // Users of Radiant may define their own default allocator. Radiant itself
@@ -122,5 +123,20 @@ public:
     void* ReallocBytes(void* ptr, SizeType size);
 };
 #endif
+
+//
+// Radiant allocator concept requires:
+// - Destruction does not throw.
+// - Copying does not throw.
+// - Moving does not throw.
+// - Freeing memory does not throw.
+//
+template <typename T>
+RAD_INLINE_VAR constexpr bool AllocatorRequires =
+    (IsNoThrowDtor<T> &&                               //
+     IsNoThrowCopyCtor<T> && IsNoThrowCopyAssign<T> && //
+     IsNoThrowMoveCtor<T> && IsNoThrowMoveAssign<T> &&
+     noexcept(DeclVal<T>().Free(nullptr)) &&
+     noexcept(DeclVal<T>().FreeBytes(nullptr)));
 
 } // namespace rad

--- a/radiant/Result.h
+++ b/radiant/Result.h
@@ -326,8 +326,8 @@ public:
     using typename StorageType::OkType;
     using typename StorageType::ErrType;
 
-    RAD_S_ASSERT_NOTHROW_MOVE((IsNoThrowMoveCtor<T> && IsNoThrowMoveAssign<T> &&
-                               IsNoThrowMoveCtor<E> && IsNoThrowMoveAssign<E>));
+    RAD_S_ASSERT_NOTHROW_MOVE_T(T);
+    RAD_S_ASSERT_NOTHROW_MOVE_T(E);
 
     constexpr Result() noexcept
         : StorageType(ResultEmptyTag)

--- a/radiant/SharedPtr.h
+++ b/radiant/SharedPtr.h
@@ -180,6 +180,8 @@ public:
     using ValueType = T;
     using PairType = EmptyOptimizedPair<AllocatorType, ValueType>;
 
+    RAD_S_ASSERT_ALLOCATOR_REQUIRES_T(TAlloc);
+
     template <typename... TArgs>
     PtrBlock(const AllocatorType& alloc, TArgs&&... args) noexcept(
         noexcept(PairType(alloc, Forward<TArgs>(args)...)))
@@ -956,6 +958,8 @@ SharedPtr<T> AllocateShared(const TAlloc& alloc, TArgs&&... args) //
     noexcept(noexcept(detail::AllocateSharedImpl::AllocateShared<T, TAlloc>(
         alloc, Forward<TArgs>(args)...)))
 {
+    RAD_S_ASSERT_ALLOCATOR_REQUIRES_T(TAlloc);
+
     return detail::AllocateSharedImpl::AllocateShared<T, TAlloc>(
         alloc,
         Forward<TArgs>(args)...);
@@ -972,6 +976,8 @@ template <typename T, typename TAlloc RAD_ALLOCATOR_EQ(T), typename... TArgs>
 SharedPtr<T> MakeShared(TArgs&&... args) noexcept(
     noexcept(AllocateShared<T>(DeclVal<TAlloc&>(), Forward<TArgs>(args)...)))
 {
+    RAD_S_ASSERT_ALLOCATOR_REQUIRES_T(TAlloc);
+
     TAlloc alloc;
     return AllocateShared<T>(alloc, Forward<TArgs>(args)...);
 }

--- a/radiant/TotallyRad.h
+++ b/radiant/TotallyRad.h
@@ -270,7 +270,7 @@ inline bool DoAssert(const char* Assertion, const char* File, int Line)
 #endif
 
 //
-// Enables assertions the move operations do not throw exceptions.
+// Enables assertions that move operations do not throw exceptions.
 //
 // Core Guideline: A throwing move violates most people’s reasonable
 // assumptions. A non-throwing move will be used more efficiently by
@@ -282,13 +282,31 @@ inline bool DoAssert(const char* Assertion, const char* File, int Line)
 #if RAD_ENABLE_NOTHROW_MOVE_ASSERTIONS
 #define RAD_S_ASSERT_NOTHROW_MOVE(x)                                           \
     RAD_S_ASSERTMSG(x, "move operations should not throw")
-
 #define RAD_S_ASSERT_NOTHROW_MOVE_T(x)                                         \
-    RAD_S_ASSERTMSG(IsNoThrowMoveCtor<T>&& IsNoThrowMoveAssign<T>,             \
+    RAD_S_ASSERTMSG(IsNoThrowMoveCtor<x>&& IsNoThrowMoveAssign<x>,             \
                     "move operations should not throw")
 #else
 #define RAD_S_ASSERT_NOTHROW_MOVE(x)   RAD_S_ASSERT(true)
 #define RAD_S_ASSERT_NOTHROW_MOVE_T(x) RAD_S_ASSERT(true)
+#endif
+
+//
+// Enables assertions that allocators meet the Radiant allocator concept
+// requirements.
+//
+// See: rad::AllocatorRequires
+//
+#ifndef RAD_ENABLE_ALLOCATOR_REQUIRES_ASSERTIONS
+#define RAD_ENABLE_ALLOCATOR_REQUIRES_ASSERTIONS 1
+#endif
+#if RAD_ENABLE_ALLOCATOR_REQUIRES_ASSERTIONS
+#define RAD_S_ASSERT_ALLOCATOR_REQUIRES(x)                                     \
+    RAD_S_ASSERTMSG(x, "allocator requirements not met")
+#define RAD_S_ASSERT_ALLOCATOR_REQUIRES_T(x)                                   \
+    RAD_S_ASSERTMSG(AllocatorRequires<x>, "allocator requirements not met")
+#else
+#define RAD_S_ASSERT_ALLOCATOR_REQUIRES(x)   RAD_S_ASSERT(true)
+#define RAD_S_ASSERT_ALLOCATOR_REQUIRES_T(x) RAD_S_ASSERT(true)
 #endif
 
 #define RAD_NOT_COPYABLE(x)                                                    \

--- a/radiant/TypeWrapper.h
+++ b/radiant/TypeWrapper.h
@@ -33,7 +33,7 @@ public:
 
     using Type = T;
 
-    RAD_S_ASSERT_NOTHROW_MOVE((IsNoThrowMoveCtor<T> && IsNoThrowMoveAssign<T>));
+    RAD_S_ASSERT_NOTHROW_MOVE_T(T);
 
     template <typename U = T, EnIf<IsDefaultCtor<U>, int> = 0>
     constexpr TypeWrapper() noexcept(IsNoThrowDefaultCtor<T>)

--- a/radiant/Vector.h
+++ b/radiant/Vector.h
@@ -47,7 +47,7 @@ public:
     using OtherType = Vector<T, OtherTAllocator, OtherTInlineCount>;
 
     RAD_S_ASSERT_NOTHROW_MOVE_T(T);
-    RAD_S_ASSERT_NOTHROW_MOVE_T(TAllocator);
+    RAD_S_ASSERT_ALLOCATOR_REQUIRES_T(TAllocator);
 
     ~Vector()
     {


### PR DESCRIPTION
Implements `rad::AllocatorRequires` and static asserts in usage paths. This requirement institutes that Radiant allocators:
- Destruction does not throw.
- Copying does not throw.
- Moving does not throw.
- Freeing memory does not throw.