### PR TITLE
Fix type wrapper maybe uninitialized

### DIFF
--- a/radiant/TypeTraits.h
+++ b/radiant/TypeTraits.h
@@ -38,6 +38,9 @@ template <typename T>
 using RemoveCV = typename remove_cv<T>::type;
 
 template <typename T>
+using RemoveCVRef = RemoveCV<RemoveRef<T>>;
+
+template <typename T>
 using RemoveConst = typename remove_const<T>::type;
 
 template <typename T>

--- a/radiant/TypeWrapper.h
+++ b/radiant/TypeWrapper.h
@@ -157,6 +157,10 @@ private:
 template <typename T>
 class TypeWrapper<T, true>
 {
+private:
+
+    using PointerType = RemoveRef<T>*;
+
 public:
 
     using Type = T;
@@ -165,55 +169,55 @@ public:
 
     template <typename U, EnIf<IsCtor<T, U>, int> = 0>
     constexpr explicit TypeWrapper(U&& val) noexcept
-        : m_ref(Forward<U>(val))
+        : m_value(AddrOf(Forward<U>(val)))
     {
     }
 
     template <typename U, EnIf<IsLRefBindable<T, U&>, int> = 0>
     constexpr explicit TypeWrapper(TypeWrapper<U>& r) noexcept
-        : m_ref(r.Get())
+        : m_value(AddrOf(r.Get()))
     {
     }
 
     template <typename U, EnIf<IsLRefBindable<T, const U&>, int> = 0>
     constexpr explicit TypeWrapper(const TypeWrapper<U>& r) noexcept
-        : m_ref(r.Get())
+        : m_value(AddrOf(r.Get()))
     {
     }
 
     template <typename U, EnIf<IsLRefBindable<T, U&>, int> = 0>
     constexpr explicit TypeWrapper(TypeWrapper<U>&& r) noexcept
-        : m_ref(r.Get())
+        : m_value(AddrOf(r.Get()))
     {
     }
 
-    template <typename U, EnIf<IsCtor<T, U>, int> = 0>
+    template <typename U, EnIf<IsLRefBindable<T, U&>, int> = 0>
     constexpr TypeWrapper& operator=(U&& val) noexcept
     {
-        new (this) TypeWrapper(Forward<U>(val));
+        m_value = AddrOf(Forward<U>(val));
         return *this;
     }
 
-    template <typename U, EnIf<IsCtor<T, U&>, int> = 0>
+    template <typename U, EnIf<IsLRefBindable<T, U&>, int> = 0>
     constexpr TypeWrapper& operator=(TypeWrapper<U>& r) noexcept
     {
-        new (this) TypeWrapper(r.Get());
+        m_value = AddrOf(r.Get());
         return *this;
     }
 
     constexpr T& Get() noexcept
     {
-        return m_ref;
+        return *m_value;
     }
 
     constexpr const T& Get() const noexcept
     {
-        return m_ref;
+        return *m_value;
     }
 
 private:
 
-    T m_ref;
+    PointerType m_value;
 };
 
 template <typename T, typename U>

--- a/test/test_Result.cpp
+++ b/test/test_Result.cpp
@@ -29,11 +29,6 @@
 #include <string>
 #include <utility>
 
-#if !RAD_DBG && defined(RAD_GCC_VERSION)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 namespace testnoexcept
 {
 
@@ -3193,7 +3188,3 @@ TEST(ResultTests, CompareRes)
     EXPECT_FALSE(value != rad::ResultErr<MYSTATUS>(MYSTATUS_UNSUCCESSFUL));
     EXPECT_FALSE(rad::ResultErr<MYSTATUS>(MYSTATUS_UNSUCCESSFUL) != value);
 }
-
-#if !RAD_DBG && defined(RAD_GCC_VERSION)
-#pragma GCC diagnostic pop
-#endif

--- a/test/test_TypeWrapper.cpp
+++ b/test/test_TypeWrapper.cpp
@@ -43,9 +43,11 @@ RAD_S_ASSERT(!noexcept(TW<TO>(rad::DeclVal<TO&>())));
 RAD_S_ASSERT(noexcept(TW<NTO>(rad::DeclVal<NTO&&>())));
 RAD_S_ASSERT(!noexcept(TW<TO>(rad::DeclVal<TO&&>())));
 
+#if RAD_ENABLE_STD
 // noexcept passthrough initializer_list ctor
 RAD_S_ASSERT(noexcept(TW<NTO>({ 1, 2 })));
 RAD_S_ASSERT(!noexcept(TW<TO>({ 1, 2 })));
+#endif
 
 // noexcept passthrough wrapper default copy ctor
 RAD_S_ASSERT(noexcept(TW<NTO>(rad::DeclVal<TW<NTO>&>())));


### PR DESCRIPTION
Converts type wrapper of a reference to use a pointer. This resolves GCC maybe uninitialized problems. It also optimizes since (I believe) the construction on assignment was strictly unnecessary given the known reference type, a simple pointer assignment should suffice.