### PR TITLE
Allocator redesign

### DIFF
--- a/default_copts.bzl
+++ b/default_copts.bzl
@@ -44,6 +44,7 @@ RAD_GCC_COPTS = [
     "-Wvarargs",
     "-Wvla",
     "-Wwrite-strings",
+    "-Wno-multichar",
     "-Werror",
     "-Wpedantic",
 ]

--- a/radiant/Memory.h
+++ b/radiant/Memory.h
@@ -15,7 +15,16 @@
 #pragma once
 
 #include "radiant/TotallyRad.h"
+#include "radiant/Algorithm.h"
 #include "radiant/TypeTraits.h"
+#include "radiant/Utility.h"
+#include "radiant/detail/Meta.h"
+
+#include <stddef.h>
+
+#if RAD_ENABLE_STD
+#include <memory>
+#endif
 
 //
 // Users of Radiant may define their own default allocator. Radiant itself
@@ -23,8 +32,8 @@
 // enforce verbosity if they wish.
 //
 #ifdef RAD_DEFAULT_ALLOCATOR
-#define RAD_ALLOCATOR(x)    RAD_DEFAULT_ALLOCATOR<x>
-#define RAD_ALLOCATOR_EQ(x) = RAD_DEFAULT_ALLOCATOR<x>
+#define RAD_ALLOCATOR(x)    RAD_DEFAULT_ALLOCATOR
+#define RAD_ALLOCATOR_EQ(x) = RAD_DEFAULT_ALLOCATOR
 #else
 #define RAD_ALLOCATOR(x)
 #define RAD_ALLOCATOR_EQ(x)
@@ -33,110 +42,400 @@
 namespace rad
 {
 
-#if 0
-/// @brief Example Radiant compatible allocator.
-/// @details Note that this allocator has no implementation and exists only as
-/// an example for allocator implementors. Consider it a concept contract for an
-/// allocator compatible with Radiant.
-/// @tparam T The type of object to allocate.
+namespace detection
+{
+
+// helper macro for stamping out traits that default to false
+#define RAD_TRAIT_DETECTOR(Trait)                                              \
+    template <typename T, typename = void>                                     \
+    struct Trait                                                               \
+    {                                                                          \
+        static constexpr bool Val = false;                                     \
+    };                                                                         \
+                                                                               \
+    template <typename T>                                                      \
+    struct Trait<T, meta::VoidT<decltype(T::Trait)>>                           \
+    {                                                                          \
+        static constexpr bool Val = T::Trait;                                  \
+    }
+
+RAD_TRAIT_DETECTOR(PropagateOnCopy);
+RAD_TRAIT_DETECTOR(PropagateOnMoveAssignment);
+RAD_TRAIT_DETECTOR(PropagateOnSwap);
+RAD_TRAIT_DETECTOR(HasConstructAndDestroy);
+RAD_TRAIT_DETECTOR(HasTypedAllocations);
+
+#undef RAD_TRAIT_DETECTOR
+
+// If your class is empty, then you can use the default of "True" for
+// IsAlwaysEqual. Everyone else needs to define IsAlwaysEqual in their class.
+template <typename T, typename = void>
+struct IsAlwaysEqual
+{
+    RAD_S_ASSERTMSG(IsEmpty<T>,
+                    "Non-empty Allocators must define IsAlwaysEqual");
+    static constexpr bool Val = true;
+};
+
 template <typename T>
-class Allocator
+struct IsAlwaysEqual<T, meta::VoidT<decltype(T::IsAlwaysEqual)>>
+{
+    static constexpr bool Val = T::IsAlwaysEqual;
+};
+
+} // namespace detection
+
+template <typename AllocT>
+class AllocTraits
 {
 public:
 
-    /// @brief Trait indicating if freeing memory is required.
-    /// @details If this is false, users of the allocator need not free memory
-    /// that was allocated. This trait enables certain run or compile time
-    /// optimizations. An example of an allocator that might leverage this trait
-    /// is a stack allocator. When false, an allocator implementor may implement
-    /// a no-op Free function.
-    static constexpr bool NeedsFree = true;
+    static constexpr bool PropagateOnCopy =
+        detection::PropagateOnCopy<AllocT>::Val; // defaults to false
+    static constexpr bool PropagateOnMoveAssignment =
+        detection::PropagateOnMoveAssignment<AllocT>::Val; // defaults to false
+    static constexpr bool PropagateOnSwap =
+        detection::PropagateOnSwap<AllocT>::Val; // defaults to false
+    static constexpr bool IsAlwaysEqual =
+        detection::IsAlwaysEqual<AllocT>::Val; // defaults to true when is_empty
+    static constexpr bool HasConstructAndDestroy =
+        detection::HasConstructAndDestroy<AllocT>::Val; // defaults to false
+    static constexpr bool HasTypedAllocations =
+        detection::HasTypedAllocations<AllocT>::Val; // defaults to false
 
-    /// @brief Trait indicating if the allocator supports reallocations.
-    /// @details If this is false, users of the allocator should not call
-    /// Realloc as the allocator does not support it. In some scenarios it may
-    /// be possible and more efficient to reallocate memory in place rather than
-    /// allocating new memory. When false, an allocator implementor may
-    /// implement a no-op Realloc function.
-    static constexpr bool HasRealloc = true;
+    static constexpr size_t MaxSize = ~size_t(0);
 
-    /// @brief Trait indicating if the allocator supports allocating by bytes.
-    /// @details If this is true, users of the allocator may call the Bytes
-    /// suffixed functions to allocate and free memory as bytes rather than as
-    /// number of T elements. An example is cases where some memory needs
-    /// allocated before or after T. However it may not be possible for all types
-    /// of allocators, such as a slab/lookaside allocator. When false, an
-    /// allocator may implement appropriate no-op functions for the various Bytes
-    /// suffixes function.
-    static constexpr bool HasAllocBytes = true;
-
-    using ThisType = Allocator<T>;
-    using ValueType = T;
-    using SizeType = uint32_t;
-    using DifferenceType = ptrdiff_t;
-
-    ~Allocator() = default;
-
-    constexpr Allocator() noexcept = default;
-
-    constexpr Allocator(const Allocator&) noexcept = default;
-
-    template <typename U>
-    constexpr Allocator(const Allocator<U>&) noexcept
+    // basis operations
+    static void* AllocBytes(AllocT& a, size_t size)
     {
+        return a.AllocBytes(size);
     }
 
-    template <typename U>
-    struct Rebind
+    static void FreeBytes(AllocT& a, void* ptr, size_t size) noexcept
     {
-        using Other = Allocator<U>;
-    };
+        RAD_S_ASSERTMSG(noexcept(a.FreeBytes(ptr, size)),
+                        "Allocator::FreeBytes must be noexcept");
+        a.FreeBytes(ptr, size);
+    }
 
-    /// @brief Frees memory allocated by Alloc.
-    /// @param ptr Pointer to the memory to free.
-    void Free(ValueType* ptr) noexcept;
+    // typed operations
+    template <typename T>
+    static constexpr T* Alloc(AllocT& a, size_t n)
+    {
+        return AllocImpl<T>(IntegralConstant<bool, HasTypedAllocations>{},
+                            a,
+                            n);
+    }
 
-    /// @brief Allocates memory for count number of T.
-    /// @param count The number of T to allocate memory for.
-    /// @return Pointer to the allocated memory.
-    ValueType* Alloc(SizeType count);
+    template <typename T>
+    static constexpr void Free(AllocT& a, T* p, size_t n) noexcept
+    {
+        FreeImpl(IntegralConstant<bool, HasTypedAllocations>{}, a, p, n);
+    }
 
-    /// @brief Reallocates memory for count number of T.
-    /// @param ptr Pointer to the memory to reallocate. If nullptr a new memory block is allocated.
-    /// @param count The number of T to allocate memory for.
-    /// @return Pointer to the reallocated memory.
-    ValueType* Realloc(ValueType* ptr, SizeType count);
+    // constexpr construct and destroy operations
+    template <class T, class... Args>
+    static constexpr T* Construct(AllocT& a, T* p, Args&&... args)
+    {
+        return ConstructImpl(IntegralConstant<bool, HasConstructAndDestroy>{},
+                             a,
+                             p,
+                             Forward<Args>(args)...);
+    }
 
-    /// @brief Frees memory allocated by AllocBytes.
-    /// @param ptr Pointer to the memory to free.
-    void FreeBytes(void* ptr) noexcept;
+    template <class T>
+    static constexpr void Destroy(AllocT& a, T* p) noexcept
+    {
+        DestroyImpl(IntegralConstant<bool, HasConstructAndDestroy>{}, a, p);
+    }
 
-    /// @brief Allocates memory for size number of bytes.
-    /// @param size The number of bytes to allocate memory for.
-    /// @return Pointer to the allocated memory.
-    void* AllocBytes(SizeType size);
+    static constexpr bool Equal(const AllocT& a, const AllocT& b) noexcept
+    {
+        return EqualImpl(IntegralConstant<bool, IsAlwaysEqual>{}, a, b);
+    }
 
-    /// @brief Reallocates memory for size number of bytes.
-    /// @param ptr Pointer to the memory to reallocate. If nullptr a new memory block is allocated.
-    /// @param size The number of bytes to allocate memory for.
-    /// @return Pointer to the reallocated memory.
-    void* ReallocBytes(void* ptr, SizeType size);
+    static constexpr void PropagateOnMoveIfNeeded(AllocT& dest,
+                                                  AllocT& src) noexcept
+    {
+        return PropagateIfNeededImpl(IntegralConstant < bool,
+                                     PropagateOnMoveAssignment &&
+                                         !IsAlwaysEqual > {},
+                                     dest,
+                                     src);
+    }
+
+    static constexpr void PropagateOnCopyIfNeeded(AllocT& a, AllocT& b) noexcept
+    {
+        return PropagateIfNeededImpl(IntegralConstant < bool,
+                                     PropagateOnCopy && !IsAlwaysEqual > {},
+                                     a,
+                                     b);
+    }
+
+    static constexpr void PropagateOnSwapIfNeeded(AllocT& a, AllocT& b) noexcept
+    {
+        return PropagateOnSwapIfNeededImpl(IntegralConstant < bool,
+                                           PropagateOnSwap &&
+                                               !IsAlwaysEqual > {},
+                                           a,
+                                           b);
+    }
+
+    static constexpr AllocT SelectAllocOnCopy(const AllocT& src_alloc) noexcept
+    {
+        RAD_S_ASSERTMSG(PropagateOnCopy || IsAlwaysEqual ||
+                            IsDefaultCtor<AllocT>,
+                        "You are attempting to copy / clone a container, but "
+                        "your allocator doesn't want to PropagateOnCopy, and "
+                        "we can't default construct your allocator.");
+        return SelectAllocOnCopyImpl(IntegralConstant < bool,
+                                     IsAlwaysEqual || PropagateOnCopy > {},
+                                     src_alloc);
+    }
+
+private:
+
+    // static assert the primary requirements.  There are additional
+    // requirements in some of the customization points, and we static assert
+    // if you provide the customization without meeting the additional
+    // requirements.
+    RAD_S_ASSERTMSG(IsNoThrowDtor<AllocT>                    //
+                        && IsNoThrowCopyCtor<AllocT>         //
+                            && IsNoThrowCopyAssign<AllocT>   //
+                                && IsNoThrowMoveCtor<AllocT> //
+                                    && IsNoThrowMoveAssign<AllocT>,
+                    "Allocator requirements not met");
+
+    template <typename T>
+    static constexpr T* AllocImpl(TrueType, // HasTypedAllocations
+                                  AllocT& a,
+                                  size_t n)
+    {
+        return a.template Alloc<T>(n);
+    }
+
+    template <typename T>
+    static constexpr T* AllocImpl(FalseType, // !HasTypedAllocations
+                                  AllocT& a,
+                                  size_t n)
+    {
+        if (n > MaxSize / sizeof(T))
+        {
+            // If you want to keep returning nullptr, make your
+            // HandleSizeOverflow a no-op. If you want an exception or an
+            // assertion, then do that instead.
+            a.HandleSizeOverflow();
+            return nullptr;
+        }
+
+        void* mem = a.AllocBytes(n * sizeof(T));
+        return static_cast<T*>(mem);
+    }
+
+    template <typename T>
+    static constexpr void FreeImpl(TrueType, // HasTypedAllocations
+                                   AllocT& a,
+                                   T* p,
+                                   size_t n) noexcept
+    {
+        RAD_S_ASSERTMSG(noexcept(a.Free(p, n)),
+                        "Allocator::Free must be noexcept");
+        return a.Free(p, n);
+    }
+
+    template <typename T>
+    static constexpr void FreeImpl(FalseType, // !HasTypedAllocations
+                                   AllocT& a,
+                                   T* p,
+                                   size_t n) noexcept
+    {
+        RAD_FAST_FAIL((p == nullptr) || (n <= MaxSize / sizeof(T)));
+        a.FreeBytes(p, n * sizeof(T));
+    }
+
+    template <class T, class... Args>
+    static constexpr T* ConstructImpl(TrueType, // HasConstructAndDestroy
+                                      AllocT& a,
+                                      T* p,
+                                      Args&&... args)
+    {
+        return a.Construct(p, Forward<Args>(args)...);
+    }
+
+    template <class T, class... Args>
+    static constexpr T* ConstructImpl(FalseType, // !HasConstructAndDestroy
+                                      AllocT& a,
+                                      T* p,
+                                      Args&&... args)
+    {
+        RAD_UNUSED(a);
+        return ::new (static_cast<void*>(p)) T(Forward<Args>(args)...);
+    }
+
+    template <class T>
+    static constexpr void DestroyImpl(TrueType, // HasConstructAndDestroy
+                                      AllocT& a,
+                                      T* p) noexcept
+    {
+        RAD_S_ASSERTMSG(noexcept(a.Destroy(p)),
+                        "Allocator::Destroy must be noexcept");
+        a.Destroy(p);
+    }
+
+    template <class T>
+    static constexpr void DestroyImpl(FalseType, // !HasConstructAndDestroy
+                                      AllocT& a,
+                                      T* p) noexcept
+    {
+        RAD_UNUSED(a);
+        p->~T();
+    }
+
+    static constexpr bool EqualImpl(TrueType, // IsAlwaysEqual
+                                    const AllocT& a,
+                                    const AllocT& b) noexcept
+    {
+        RAD_UNUSED(a);
+        RAD_UNUSED(b);
+        return true;
+    }
+
+    static constexpr bool EqualImpl(FalseType, // !IsAlwaysEqual
+                                    const AllocT& a,
+                                    const AllocT& b) noexcept
+    {
+        RAD_S_ASSERTMSG(noexcept(a == b),
+                        "Allocator::operator== must be noexcept");
+        return a == b;
+    }
+
+    static constexpr void PropagateIfNeededImpl(
+        TrueType, // PropagateOn* && !IsAlwaysEqual
+        AllocT& dest,
+        AllocT& src) noexcept
+    {
+        if (!(dest == src)) // avoid using !=, as AllocT may not define it
+        {
+            dest = src;
+        }
+    }
+
+    static constexpr void PropagateIfNeededImpl(
+        FalseType, // ! (PropagateOn* && !IsAlwaysEqual)
+        AllocT& dest,
+        AllocT& src) noexcept
+    {
+        RAD_UNUSED(dest);
+        RAD_UNUSED(src);
+    }
+
+    static constexpr void PropagateOnSwapIfNeededImpl(
+        TrueType, // PropagateOnSwap && !IsAlwaysEqual
+        AllocT& a,
+        AllocT& b) noexcept
+    {
+        using rad::Swap;
+        Swap(a, b);
+    }
+
+    static constexpr void PropagateOnSwapIfNeededImpl(
+        FalseType, // ! (PropagateOnSwap && !IsAlwaysEqual)
+        AllocT& a,
+        AllocT& b) noexcept
+    {
+        RAD_UNUSED(a);
+        RAD_UNUSED(b);
+    }
+
+    static constexpr AllocT SelectAllocOnCopyImpl(
+        TrueType, // IsAlwaysEqual || PropagateOnCopy
+        const AllocT& src_alloc) noexcept
+    {
+        return src_alloc;
+    }
+
+    static constexpr AllocT SelectAllocOnCopyImpl(
+        FalseType, // !(IsAlwaysEqual || PropagateOnCopy)
+        const AllocT& src_alloc) noexcept
+    {
+        RAD_UNUSED(src_alloc);
+        return AllocT();
+    }
 };
-#endif
 
-//
-// Radiant allocator concept requires:
-// - Destruction does not throw.
-// - Copying does not throw.
-// - Moving does not throw.
-// - Freeing memory does not throw.
-//
-template <typename T>
-RAD_INLINE_VAR constexpr bool AllocatorRequires =
-    (IsNoThrowDtor<T> &&                               //
-     IsNoThrowCopyCtor<T> && IsNoThrowCopyAssign<T> && //
-     IsNoThrowMoveCtor<T> && IsNoThrowMoveAssign<T> &&
-     noexcept(DeclVal<T>().Free(nullptr)) &&
-     noexcept(DeclVal<T>().FreeBytes(nullptr)));
+#if RAD_ENABLE_STD && RAD_USER_MODE
+class StdAllocator
+{
+public:
+
+    static constexpr bool PropagateOnCopy = false;
+    static constexpr bool PropagateOnMoveAssignment = false;
+    static constexpr bool PropagateOnSwap = false;
+    static constexpr bool IsAlwaysEqual = true;
+
+    static constexpr bool HasTypedAllocations = true;
+    static constexpr bool HasConstructAndDestroy = true;
+
+    constexpr bool operator==(const StdAllocator& /*rhs*/) const noexcept
+    {
+        return true;
+    }
+
+    constexpr bool operator!=(const StdAllocator& /*rhs*/) const noexcept
+    {
+        return false;
+    }
+
+    // Allocate and free are intentionally not constexpr.  Constexpr evaluation
+    // requires typed parameters.
+    static void* AllocBytes(size_t size)
+    {
+        std::allocator<char> al;
+        return al.allocate(size);
+    }
+
+    static void FreeBytes(void* ptr, size_t size) noexcept
+    {
+        std::allocator<char> al;
+        return al.deallocate(static_cast<char*>(ptr), size);
+    }
+
+    template <typename T>
+    static constexpr T* Alloc(size_t count)
+    {
+        std::allocator<T> al;
+        return al.allocate(count);
+    }
+
+    template <typename T>
+    static constexpr void Free(T* ptr, size_t count) noexcept
+    {
+        std::allocator<T> al;
+        return al.deallocate(ptr, count);
+    }
+
+    template <class T, class... Args>
+    static constexpr T* Construct(T* p, Args&&... args)
+    {
+        // use allocator_traits, because std::allocator::construct was removed
+        // in C++20, and construct_at wasn't added until C++20.
+        std::allocator<T> al;
+        std::allocator_traits<std::allocator<T>>::construct(
+            al,
+            p,
+            Forward<Args>(args)...);
+        return p;
+    }
+
+    template <class T>
+    static constexpr void Destroy(T* p) noexcept
+    {
+        // use allocator_traits, because std::allocator::destroy was removed in
+        // C++20, and destroy_at wasn't added until C++17
+        std::allocator<T> al;
+        std::allocator_traits<std::allocator<T>>::destroy(al, p);
+    }
+};
+#endif // RAD_ENABLE_STD && RAD_USER_MODE ^^^
 
 } // namespace rad

--- a/radiant/TotallyRad.h
+++ b/radiant/TotallyRad.h
@@ -296,25 +296,6 @@ extern "C" __declspec(noreturn) void __fastfail(unsigned int code);
 #define RAD_S_ASSERT_NOTHROW_MOVE_T(x) RAD_S_ASSERT(true)
 #endif
 
-//
-// Enables assertions that allocators meet the Radiant allocator concept
-// requirements.
-//
-// See: rad::AllocatorRequires
-//
-#ifndef RAD_ENABLE_ALLOCATOR_REQUIRES_ASSERTIONS
-#define RAD_ENABLE_ALLOCATOR_REQUIRES_ASSERTIONS 1
-#endif
-#if RAD_ENABLE_ALLOCATOR_REQUIRES_ASSERTIONS
-#define RAD_S_ASSERT_ALLOCATOR_REQUIRES(x)                                     \
-    RAD_S_ASSERTMSG(x, "allocator requirements not met")
-#define RAD_S_ASSERT_ALLOCATOR_REQUIRES_T(x)                                   \
-    RAD_S_ASSERT_ALLOCATOR_REQUIRES(::rad::AllocatorRequires<x>)
-#else
-#define RAD_S_ASSERT_ALLOCATOR_REQUIRES(x)   RAD_S_ASSERT(true)
-#define RAD_S_ASSERT_ALLOCATOR_REQUIRES_T(x) RAD_S_ASSERT(true)
-#endif
-
 #define RAD_NOT_COPYABLE(x)                                                    \
     x(x const&) = delete;                                                      \
     x& operator=(x const&) = delete

--- a/radiant/TotallyRad.h
+++ b/radiant/TotallyRad.h
@@ -72,12 +72,12 @@
 
 #if defined(__clang__) && __clang__
 #define RAD_CLANG_VERSION                                                      \
-    (__clang_major__ * 10000 + __clang_minor__ + 100 + __clang_patchlevel__)
+    (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 #endif
 
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__
 #define RAD_GCC_VERSION                                                        \
-    (__GNUC__ * 10000 + __GNUC__MINOR__ + 100 + __GNUC_PATCHLEVEL__)
+    (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER

--- a/radiant/TypeTraits.h
+++ b/radiant/TypeTraits.h
@@ -129,7 +129,7 @@ struct EnIfUnrelated<T, U, Rest...> : enable_if<!IsRelated<T, U>>
 template <typename T, T TValue>
 using IntegralConstant = integral_constant<T, TValue>;
 using TrueType = IntegralConstant<bool, true>;
-using FalseType = IntegralConstant<bool, true>;
+using FalseType = IntegralConstant<bool, false>;
 
 template <typename T>
 RAD_INLINE_VAR constexpr bool IsIntegral = is_integral<T>::value;

--- a/test/TestAlloc.cpp
+++ b/test/TestAlloc.cpp
@@ -19,98 +19,16 @@
 namespace radtest
 {
 
-uint32_t CountingAllocatorImpl::g_FreeCount = 0;
-uint32_t CountingAllocatorImpl::g_AllocCount = 0;
-uint32_t CountingAllocatorImpl::g_ReallocCount = 0;
-uint32_t CountingAllocatorImpl::g_FreeBytesCount = 0;
-uint32_t CountingAllocatorImpl::g_AllocBytesCount = 0;
-uint32_t CountingAllocatorImpl::g_ReallocBytesCount = 0;
+const uint32_t StatefulAllocator::k_BadState;
+const uint32_t StatefulCountingAllocator::k_BadState;
 
-void CountingAllocatorImpl::Free(void* ptr) noexcept
-{
-    ++g_FreeCount;
-    free(ptr);
-}
-
-void* CountingAllocatorImpl::Alloc(uint32_t size) noexcept
-{
-    ++g_AllocCount;
-    return malloc(size);
-}
-
-void* CountingAllocatorImpl::Realloc(void* ptr, uint32_t size) noexcept
-{
-    ++g_ReallocCount;
-    return realloc(ptr, size);
-}
-
-void CountingAllocatorImpl::FreeBytes(void* ptr) noexcept
-{
-    ++g_FreeBytesCount;
-    free(ptr);
-}
-
-void* CountingAllocatorImpl::AllocBytes(uint32_t size) noexcept
-{
-    ++g_AllocBytesCount;
-    return malloc(size);
-}
-
-void* CountingAllocatorImpl::ReallocBytes(void* ptr, uint32_t size) noexcept
-{
-    ++g_ReallocBytesCount;
-    return realloc(ptr, size);
-}
-
-uint32_t CountingAllocatorImpl::FreeCount() noexcept
-{
-    return g_FreeCount;
-}
-
-uint32_t CountingAllocatorImpl::AllocCount() noexcept
-{
-    return g_AllocCount;
-}
-
-uint32_t CountingAllocatorImpl::ReallocCount() noexcept
-{
-    return g_ReallocCount;
-}
-
-uint32_t CountingAllocatorImpl::FreeBytesCount() noexcept
-{
-    return g_FreeBytesCount;
-}
-
-uint32_t CountingAllocatorImpl::AllocBytesCount() noexcept
-{
-    return g_AllocBytesCount;
-}
-
-uint32_t CountingAllocatorImpl::ReallocBytesCount() noexcept
-{
-    return g_ReallocBytesCount;
-}
-
-void CountingAllocatorImpl::ResetCounts() noexcept
-{
-    g_FreeCount = 0;
-    g_AllocCount = 0;
-    g_ReallocCount = 0;
-    g_FreeBytesCount = 0;
-    g_AllocBytesCount = 0;
-    g_ReallocBytesCount = 0;
-}
-
-bool CountingAllocatorImpl::VerifyCounts() noexcept
-{
-    return (g_AllocCount == g_FreeCount);
-}
-
-bool CountingAllocatorImpl::VerifyCounts(uint32_t expectedAllocs,
-                                         uint32_t expectedFrees) noexcept
-{
-    return (g_AllocCount == expectedAllocs) && (g_FreeCount == expectedFrees);
-}
+uint32_t CountingAllocator::g_FreeCount = 0;
+uint32_t CountingAllocator::g_AllocCount = 0;
+size_t CountingAllocator::g_FreeBytesCount = 0;
+size_t CountingAllocator::g_AllocBytesCount = 0;
+uint32_t StatefulCountingAllocator::g_FreeCount = 0;
+uint32_t StatefulCountingAllocator::g_AllocCount = 0;
+size_t StatefulCountingAllocator::g_FreeBytesCount = 0;
+size_t StatefulCountingAllocator::g_AllocBytesCount = 0;
 
 } // namespace radtest

--- a/test/test_Allocators.cpp
+++ b/test/test_Allocators.cpp
@@ -1,0 +1,372 @@
+// Copyright 2024 The Radiant Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include "radiant/Memory.h"
+
+#include "TestAlloc.h"
+
+struct TrackCtorDtor
+{
+    static int CtorCount;
+    static int DtorCount;
+    static int OtherCtorCount;
+
+    TrackCtorDtor()
+    {
+        ++CtorCount;
+    }
+
+    explicit TrackCtorDtor(uint64_t val)
+        : m_dummy_data(val)
+    {
+        ++OtherCtorCount;
+    }
+
+    ~TrackCtorDtor()
+    {
+        ++DtorCount;
+    }
+
+    static void Reset()
+    {
+        CtorCount = 0;
+        DtorCount = 0;
+        OtherCtorCount = 0;
+    }
+
+    uint64_t m_dummy_data;
+};
+
+int TrackCtorDtor::CtorCount = 0;
+int TrackCtorDtor::DtorCount = 0;
+int TrackCtorDtor::OtherCtorCount = 0;
+
+TEST(AllocatorTests, MinimalAlloc)
+{
+    radtest::Mallocator mal;
+    using allt = rad::AllocTraits<radtest::Mallocator>;
+    RAD_S_ASSERT(allt::PropagateOnCopy == false);
+    RAD_S_ASSERT(allt::PropagateOnMoveAssignment == false);
+    RAD_S_ASSERT(allt::PropagateOnSwap == false);
+    RAD_S_ASSERT(allt::IsAlwaysEqual == true);
+    RAD_S_ASSERT(allt::HasConstructAndDestroy == false);
+    RAD_S_ASSERT(allt::HasTypedAllocations == false);
+
+    {
+        void* vmem = allt::AllocBytes(mal, 1);
+        EXPECT_NE(vmem, nullptr);
+        allt::FreeBytes(mal, vmem, 1);
+
+        allt::FreeBytes(mal, nullptr, 1);
+    }
+
+    {
+        static constexpr size_t kBiggest = ~size_t(0);
+        static constexpr size_t kEltsToAttempt = kBiggest / 2;
+
+        uint64_t* too_much = allt::Alloc<uint64_t>(mal, kEltsToAttempt);
+        EXPECT_EQ(too_much, nullptr);
+        allt::Free(mal, too_much, kEltsToAttempt);
+
+        uint64_t* unull = nullptr;
+        allt::Free(mal, unull, kEltsToAttempt);
+    }
+
+    {
+        TrackCtorDtor::Reset();
+        TrackCtorDtor* tmem = allt::Alloc<TrackCtorDtor>(mal, 4);
+        EXPECT_NE(tmem, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        // check alignment
+        uintptr_t mask = alignof(TrackCtorDtor) - 1;
+        uintptr_t tmem_num = reinterpret_cast<uintptr_t>(tmem);
+        EXPECT_EQ((tmem_num & mask), 0u);
+
+        TrackCtorDtor* constructed = allt::Construct(mal, tmem);
+        EXPECT_NE(constructed, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        allt::Destroy(mal, constructed);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        TrackCtorDtor* other_constructed = allt::Construct(mal, tmem, 42u);
+        EXPECT_NE(other_constructed, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+
+        allt::Destroy(mal, other_constructed);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 2);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+
+        allt::Free(mal, tmem, 4);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 2);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+    }
+
+    {
+        radtest::Mallocator mal2;
+        EXPECT_TRUE(allt::Equal(mal, mal2));
+        EXPECT_TRUE(allt::Equal(mal2, mal));
+        EXPECT_TRUE(allt::Equal(mal, radtest::Mallocator{}));
+    }
+}
+
+TEST(AllocatorTests, PropagatingAllocator)
+{
+    constexpr uint32_t kMainTag = 42;
+    radtest::MovingTaggedAllocator tal(kMainTag);
+    using allt = rad::AllocTraits<radtest::MovingTaggedAllocator>;
+    RAD_S_ASSERT(allt::PropagateOnCopy == true);
+    RAD_S_ASSERT(allt::PropagateOnMoveAssignment == true);
+    RAD_S_ASSERT(allt::PropagateOnSwap == true);
+    RAD_S_ASSERT(allt::IsAlwaysEqual == false);
+    RAD_S_ASSERT(allt::HasConstructAndDestroy == false);
+    RAD_S_ASSERT(allt::HasTypedAllocations == false);
+
+    {
+        void* vmem = allt::AllocBytes(tal, 1);
+        EXPECT_NE(vmem, nullptr);
+        allt::FreeBytes(tal, vmem, 1);
+
+        allt::FreeBytes(tal, nullptr, 1);
+    }
+
+    {
+        static constexpr size_t kBiggest = ~size_t(0);
+        static constexpr size_t kEltsToAttempt = kBiggest / 2;
+
+        uint64_t* too_much = allt::Alloc<uint64_t>(tal, kEltsToAttempt);
+        EXPECT_EQ(too_much, nullptr);
+        allt::Free(tal, too_much, kEltsToAttempt);
+
+        uint64_t* unull = nullptr;
+        allt::Free(tal, unull, kEltsToAttempt);
+    }
+
+    {
+        TrackCtorDtor::Reset();
+        TrackCtorDtor* tmem = allt::Alloc<TrackCtorDtor>(tal, 4);
+        EXPECT_NE(tmem, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        // check alignment
+        uintptr_t mask = alignof(TrackCtorDtor) - 1;
+        uintptr_t tmem_num = reinterpret_cast<uintptr_t>(tmem);
+        EXPECT_EQ((tmem_num & mask), 0u);
+
+        TrackCtorDtor* constructed = allt::Construct(tal, tmem);
+        EXPECT_NE(constructed, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        allt::Destroy(tal, constructed);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        TrackCtorDtor* other_constructed = allt::Construct(tal, tmem, 42u);
+        EXPECT_NE(other_constructed, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+
+        allt::Destroy(tal, other_constructed);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 2);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+
+        allt::Free(tal, tmem, 4);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 2);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+    }
+
+    {
+        radtest::MovingTaggedAllocator tal2 = tal;
+        EXPECT_TRUE(allt::Equal(tal, tal2));
+        EXPECT_TRUE(allt::Equal(tal2, tal));
+
+        radtest::MovingTaggedAllocator tal3(kMainTag);
+        EXPECT_TRUE(allt::Equal(tal, tal3));
+        EXPECT_TRUE(allt::Equal(tal3, tal));
+
+        radtest::MovingTaggedAllocator tal4(kMainTag + 1);
+        EXPECT_FALSE(allt::Equal(tal, tal4));
+        EXPECT_FALSE(allt::Equal(tal4, tal));
+    }
+}
+
+#if RAD_ENABLE_STD
+TEST(AllocatorTests, StdAllocator)
+{
+    rad::StdAllocator sal;
+    using allt = rad::AllocTraits<rad::StdAllocator>;
+    RAD_S_ASSERT(allt::PropagateOnCopy == false);
+    RAD_S_ASSERT(allt::PropagateOnMoveAssignment == false);
+    RAD_S_ASSERT(allt::PropagateOnSwap == false);
+    RAD_S_ASSERT(allt::IsAlwaysEqual == true);
+    RAD_S_ASSERT(allt::HasConstructAndDestroy == true);
+    RAD_S_ASSERT(allt::HasTypedAllocations == true);
+
+    {
+        void* vmem = allt::AllocBytes(sal, 1);
+        EXPECT_NE(vmem, nullptr);
+        allt::FreeBytes(sal, vmem, 1);
+    }
+
+    {
+        TrackCtorDtor::Reset();
+        TrackCtorDtor* tmem = allt::Alloc<TrackCtorDtor>(sal, 4);
+        EXPECT_NE(tmem, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        // check alignment
+        uintptr_t mask = alignof(TrackCtorDtor) - 1;
+        uintptr_t tmem_num = reinterpret_cast<uintptr_t>(tmem);
+        EXPECT_EQ((tmem_num & mask), 0u);
+
+        TrackCtorDtor* constructed = allt::Construct(sal, tmem);
+        EXPECT_NE(constructed, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 0);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        allt::Destroy(sal, constructed);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 0);
+
+        TrackCtorDtor* other_constructed = allt::Construct(sal, tmem, 42);
+        EXPECT_NE(other_constructed, nullptr);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+
+        allt::Destroy(sal, other_constructed);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 2);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+
+        allt::Free(sal, tmem, 4);
+        EXPECT_EQ(TrackCtorDtor::CtorCount, 1);
+        EXPECT_EQ(TrackCtorDtor::DtorCount, 2);
+        EXPECT_EQ(TrackCtorDtor::OtherCtorCount, 1);
+    }
+
+    {
+        rad::StdAllocator sal2;
+        EXPECT_TRUE(allt::Equal(sal, sal2));
+        EXPECT_TRUE(allt::Equal(sal2, sal));
+        EXPECT_TRUE(allt::Equal(sal, rad::StdAllocator{}));
+
+        EXPECT_TRUE(sal == sal2);
+        EXPECT_FALSE(sal != sal2);
+    }
+}
+
+#if RAD_CPP20
+constexpr bool test_constexpr_StdAllocator()
+{
+    rad::StdAllocator sal;
+    using allt = rad::AllocTraits<rad::StdAllocator>;
+
+    {
+        uint64_t* tmem = allt::Alloc<uint64_t>(sal, 4);
+        assert(tmem != nullptr);
+
+        uint64_t* constructed = allt::Construct(sal, tmem);
+        assert(constructed != nullptr);
+
+        *constructed = 19;
+
+        allt::Destroy(sal, constructed);
+
+        uint64_t* other_constructed = allt::Construct(sal, tmem, 42);
+        assert(other_constructed != nullptr);
+        assert(*other_constructed == 42);
+
+        allt::Destroy(sal, other_constructed);
+        allt::Free(sal, tmem, 4);
+    }
+
+    {
+        rad::StdAllocator sal2;
+        RAD_UNUSED(sal2);
+        assert(allt::Equal(sal, sal2));
+        assert(allt::Equal(sal2, sal));
+        assert(allt::Equal(sal, rad::StdAllocator{}));
+    }
+    return true;
+}
+
+static_assert(test_constexpr_StdAllocator());
+
+#endif // RAD_CPP20 ^^^
+
+#endif // RAD_ENABLE_STD ^^^
+
+struct RadTestExceptionType
+{
+};
+
+struct ThrowingMallocator : radtest::Mallocator
+{
+    static void HandleSizeOverflow()
+    {
+        throw RadTestExceptionType();
+    }
+};
+
+struct BigType
+{
+    char buf[1 << 30]; // 1 GB
+};
+
+TEST(AllocatorTests, ThrowingAllocator)
+{
+    ThrowingMallocator tm;
+#if RAD_AMD64 || RAD_ARM64
+    size_t elt_count = 1ull << 40;
+#elif RAD_I386 || RAD_ARM
+    size_t elt_count = 4;
+#else
+#error "Unknown platform"
+#endif
+
+    BigType* b = nullptr;
+
+    using AllocatorTraits = rad::AllocTraits<ThrowingMallocator>;
+
+    EXPECT_THROW(b = AllocatorTraits::template Alloc<BigType>(tm, elt_count);
+                 , RadTestExceptionType);
+    EXPECT_EQ(b, nullptr);
+    AllocatorTraits::template Free<BigType>(tm, b, elt_count);
+}

--- a/test/test_EmptyOptimizedPair.cpp
+++ b/test/test_EmptyOptimizedPair.cpp
@@ -90,12 +90,12 @@ struct ThrowingStateful
 RAD_S_ASSERT(noexcept(rad::EmptyOptimizedPair<Empty, bool>()));
 RAD_S_ASSERT(!noexcept(rad::EmptyOptimizedPair<ThrowingEmpty, bool>()));
 RAD_S_ASSERT(!noexcept(rad::EmptyOptimizedPair<Empty, ThrowingEmpty>()));
-RAD_S_ASSERT(noexcept(rad::EmptyOptimizedPair<radtest::Allocator<int>, bool>(
-    rad::DeclVal<radtest::Allocator<int>&>(), true)));
-RAD_S_ASSERT(noexcept(rad::EmptyOptimizedPair<radtest::Allocator<int>, bool>(
-    rad::DeclVal<const radtest::Allocator<int>&>(), true)));
-RAD_S_ASSERT(noexcept(rad::EmptyOptimizedPair<radtest::Allocator<int>, bool>(
-    rad::DeclVal<radtest::Allocator<int>&&>(), true)));
+RAD_S_ASSERT(noexcept(rad::EmptyOptimizedPair<radtest::Mallocator, bool>(
+    rad::DeclVal<radtest::Mallocator&>(), true)));
+RAD_S_ASSERT(noexcept(rad::EmptyOptimizedPair<radtest::Mallocator, bool>(
+    rad::DeclVal<const radtest::Mallocator&>(), true)));
+RAD_S_ASSERT(noexcept(rad::EmptyOptimizedPair<radtest::Mallocator, bool>(
+    rad::DeclVal<radtest::Mallocator&&>(), true)));
 
 // empty copy ctors
 RAD_S_ASSERT(noexcept(rad::EmptyOptimizedPair<Empty, Empty>(

--- a/test/test_List.cpp
+++ b/test/test_List.cpp
@@ -449,7 +449,7 @@ TEST(ListTest, MoveAssign)
         ListEqual(one, { 101 });
         ListEqual(move_from_one, { 1, 201 });
     }
-#ifdef RAD_GCC_VERSION
+#if defined(RAD_GCC_VERSION) && RAD_GCC_VERSION >= 130000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
 #endif
@@ -472,7 +472,7 @@ TEST(ListTest, MoveAssign)
 #ifdef RAD_CLANG_VERSION
 #pragma clang diagnostic pop
 #endif
-#ifdef RAD_GCC_VERSION
+#if defined(RAD_GCC_VERSION) && RAD_GCC_VERSION >= 130000
 #pragma GCC diagnostic pop
 #endif
 }

--- a/test/test_List.cpp
+++ b/test/test_List.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#define RAD_DEFAULT_ALLOCATOR radtest::Allocator
+#define RAD_DEFAULT_ALLOCATOR radtest::Mallocator
 #include "test/TestAlloc.h"
 #include "test/TestInputStringLiteralRange.h"
 
@@ -80,7 +80,7 @@ TEST(ListTest, DefaultConstructIsEmpty)
 
 TEST(ListTest, AllocatorConstructors)
 {
-    using StatefulAlloc = radtest::StatefulAllocator<int>;
+    using StatefulAlloc = radtest::StatefulAllocator;
     {
         rad::List<int, StatefulAlloc> default_ctor;
         StatefulAlloc default_ctor_alloc = default_ctor.GetAllocator();
@@ -94,22 +94,21 @@ TEST(ListTest, AllocatorConstructors)
         StatefulAlloc alloc = alloc_ctor.GetAllocator();
         EXPECT_EQ(alloc.m_state, 42u);
 
-        // regular move constructor needs to steal the original allocator
+        // regular move constructor needs to copy the original allocator
         rad::List<int, StatefulAlloc> moving_alloc_ctor(std::move(alloc_ctor));
         StatefulAlloc moved_from_alloc = alloc_ctor.GetAllocator();
-        EXPECT_EQ(moved_from_alloc.m_state, radtest::k_MovedFromState);
+        EXPECT_EQ(moved_from_alloc.m_state, 42u);
         StatefulAlloc moved_to_alloc = moving_alloc_ctor.GetAllocator();
         EXPECT_EQ(moved_to_alloc.m_state, 42u);
 
         StatefulAlloc source_alloc2;
         source_alloc2.m_state = 99;
         rad::List<int, StatefulAlloc> move_assigned(source_alloc2);
+        // moving_alloc_ctor's "42" allocator will propagate to move_assigned
         move_assigned = std::move(moving_alloc_ctor);
         StatefulAlloc assigned_from_alloc = moving_alloc_ctor.GetAllocator();
 
-        // assigned_from_alloc should have whatever move_assigned had in it
-        // before
-        EXPECT_EQ(assigned_from_alloc.m_state, 99u);
+        EXPECT_EQ(assigned_from_alloc.m_state, 42U);
         StatefulAlloc assigned_to_alloc = move_assigned.GetAllocator();
         EXPECT_EQ(assigned_to_alloc.m_state, 42u);
     }
@@ -117,11 +116,11 @@ TEST(ListTest, AllocatorConstructors)
 
 TEST(ListTest, PushBackFailureRecovery)
 {
-    radtest::HeapAllocator heap;
-    radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
+    radtest::HeapResource heap;
+    radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
 
     {
-        rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+        rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
             alloc);
 
         EXPECT_TRUE(list.PushBack(1).IsOk());
@@ -408,6 +407,76 @@ TEST(ListTest, MoveConstruct)
     }
 }
 
+TEST(ListTest, MoveAssign)
+{
+    {
+        rad::List<int> empty;
+        rad::List<int> move_from_empty;
+        move_from_empty = std::move(empty);
+        ListEqual(empty, {});
+        ListEqual(move_from_empty, {});
+    }
+    {
+        rad::List<int> one;
+        EXPECT_TRUE(one.PushBack(1).IsOk());
+        rad::List<int> move_from_one;
+
+        move_from_one = std::move(one);
+
+        ListEqual(one, {});
+        ListEqual(move_from_one, { 1 });
+    }
+    {
+        rad::List<int> two;
+        EXPECT_TRUE(two.AssignRange(std::initializer_list<int>{ 1, 2 }).IsOk());
+
+        rad::List<int> move_from_two;
+
+        move_from_two = std::move(two);
+        ListEqual(two, {});
+        ListEqual(move_from_two, { 1, 2 });
+    }
+    {
+        rad::List<int> one;
+        EXPECT_TRUE(one.PushBack(1).IsOk());
+
+        rad::List<int> move_from_one;
+        move_from_one = std::move(one);
+
+        // ensure we can still mutate after moves
+        EXPECT_TRUE(one.PushBack(101).IsOk());
+        EXPECT_TRUE(move_from_one.PushBack(201).IsOk());
+        ListEqual(one, { 101 });
+        ListEqual(move_from_one, { 1, 201 });
+    }
+#ifdef RAD_GCC_VERSION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+#endif
+#ifdef RAD_CLANG_VERSION
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+#endif
+    {
+        rad::List<int> self_move;
+        self_move = std::move(self_move);
+        ListEqual(self_move, {});
+    }
+    {
+        rad::List<int> self_move;
+        EXPECT_TRUE(self_move.PushBack(101).IsOk());
+        self_move = std::move(self_move);
+        EXPECT_TRUE(self_move.PushBack(102).IsOk());
+        ListEqual(self_move, { 101, 102 });
+    }
+#ifdef RAD_CLANG_VERSION
+#pragma clang diagnostic pop
+#endif
+#ifdef RAD_GCC_VERSION
+#pragma GCC diagnostic pop
+#endif
+}
+
 TEST(ListTest, ClearSome)
 {
     rad::List<int> i;
@@ -519,10 +588,10 @@ TEST(ListTest, AssignCount)
 
 TEST(ListTest, Emplace)
 {
-    radtest::HeapAllocator heap;
-    radtest::AllocWrapper<ImmovableStruct, radtest::HeapAllocator> alloc(heap);
+    radtest::HeapResource heap;
+    radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
     rad::List<ImmovableStruct,
-              radtest::AllocWrapper<ImmovableStruct, radtest::HeapAllocator>>
+              radtest::ResourceAllocator<radtest::HeapResource>>
         input(alloc);
 
     // emplace at the end
@@ -571,10 +640,9 @@ TEST(ListTest, Emplace)
 
 TEST(ListTest, MoveInsert)
 {
-    radtest::HeapAllocator heap;
-    radtest::AllocWrapper<MoveStruct, radtest::HeapAllocator> alloc(heap);
-    rad::List<MoveStruct,
-              radtest::AllocWrapper<MoveStruct, radtest::HeapAllocator>>
+    radtest::HeapResource heap;
+    radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+    rad::List<MoveStruct, radtest::ResourceAllocator<radtest::HeapResource>>
         input(alloc);
 
     MoveStruct ms;
@@ -641,10 +709,9 @@ TEST(ListTest, MoveInsert)
 
 TEST(ListTest, CopyInsert)
 {
-    radtest::HeapAllocator heap;
-    radtest::AllocWrapper<CopyStruct, radtest::HeapAllocator> alloc(heap);
-    rad::List<CopyStruct,
-              radtest::AllocWrapper<CopyStruct, radtest::HeapAllocator>>
+    radtest::HeapResource heap;
+    radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+    rad::List<CopyStruct, radtest::ResourceAllocator<radtest::HeapResource>>
         input(alloc);
 
     CopyStruct cs;
@@ -710,9 +777,9 @@ TEST(ListTest, CopyInsert)
 
 TEST(ListTest, AssignFailure)
 {
-    radtest::HeapAllocator heap;
-    radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
-    rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+    radtest::HeapResource heap;
+    radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+    rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
         alloc);
 
     // AssignCount fails back to empty when it starts empty
@@ -815,6 +882,29 @@ TEST(ListTest, PostIncrPostDecr)
     EXPECT_EQ(*--pre_cend, 1);
     EXPECT_EQ(*post_cend--, 2);
 }
+
+#if !RAD_DBG
+TEST(ListTest, SelfSplice)
+{
+    rad::List<int> list;
+    EXPECT_TRUE(list.AssignRange(std::initializer_list<int>{ 1, 2, 3 }).IsOk());
+
+    list.SpliceAll(list.end(), list);
+    ListEqual(list, { 1, 2, 3 });
+    list.SpliceAll(++list.begin(), list);
+    ListEqual(list, { 1, 2, 3 });
+
+    list.SpliceOne(list.end(), list, list.begin());
+    ListEqual(list, { 1, 2, 3 });
+    list.SpliceOne(list.begin(), list, ++list.begin());
+    ListEqual(list, { 1, 2, 3 });
+
+    list.SpliceSome(list.end(), list, list.begin(), list.end());
+    ListEqual(list, { 1, 2, 3 });
+    list.SpliceSome(list.begin(), list, list.begin(), ++list.begin());
+    ListEqual(list, { 1, 2, 3 });
+}
+#endif
 
 TEST(ListTest, SpliceSomeEmpties)
 {
@@ -1432,9 +1522,9 @@ TEST(ListTest, PrependRange)
         chars.PrependRange(radtest::TestInputStringLiteralRange("abc")).IsOk());
     ListEqual(chars, { 'a', 'b', 'c', 'x', 'y', 'z' });
 
-    radtest::HeapAllocator heap;
-    radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
-    rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+    radtest::HeapResource heap;
+    radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+    rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
         alloc);
 
     EXPECT_TRUE(list.AssignRange(std::initializer_list<int>{ 1, 2, 3 }).IsOk());
@@ -1468,9 +1558,9 @@ TEST(ListTest, AppendRange)
         chars.AppendRange(radtest::TestInputStringLiteralRange("abc")).IsOk());
     ListEqual(chars, { 'x', 'y', 'z', 'a', 'b', 'c' });
 
-    radtest::HeapAllocator heap;
-    radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
-    rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+    radtest::HeapResource heap;
+    radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+    rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
         alloc);
 
     EXPECT_TRUE(list.AssignRange(std::initializer_list<int>{ 1, 2, 3 }).IsOk());
@@ -1521,9 +1611,9 @@ TEST(ListTest, InsertRange)
         ListEqual(chars, { 'x', 'a', 'b', 'c', 'y', 'z' });
     }
     {
-        radtest::HeapAllocator heap;
-        radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
-        rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+        radtest::HeapResource heap;
+        radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+        rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
             alloc);
 
         EXPECT_TRUE(
@@ -1566,9 +1656,9 @@ TEST(ListTest, InsertSome)
         ListEqual(dest, { 0, 100, 101, 1, 2, 3 });
     }
     {
-        radtest::HeapAllocator heap;
-        radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
-        rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+        radtest::HeapResource heap;
+        radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+        rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
             alloc);
 
         EXPECT_TRUE(
@@ -1609,9 +1699,9 @@ TEST(ListTest, InsertInitializerList)
         ListEqual(dest, { 0, 100, 101, 1, 2, 3 });
     }
     {
-        radtest::HeapAllocator heap;
-        radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
-        rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+        radtest::HeapResource heap;
+        radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+        rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
             alloc);
 
         EXPECT_TRUE(
@@ -1652,9 +1742,9 @@ TEST(ListTest, InsertCount)
         ListEqual(dest, { 0, 100, 100, 1, 2, 3 });
     }
     {
-        radtest::HeapAllocator heap;
-        radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
-        rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+        radtest::HeapResource heap;
+        radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+        rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
             alloc);
 
         EXPECT_TRUE(
@@ -1689,9 +1779,9 @@ TEST(ListTest, Clone)
         ListEqual(li2.Ok(), { 1, 2, 3 });
     }
     {
-        radtest::HeapAllocator heap;
-        radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
-        rad::List<int, radtest::AllocWrapper<int, radtest::HeapAllocator>> list(
+        radtest::HeapResource heap;
+        radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
+        rad::List<int, radtest::ResourceAllocator<radtest::HeapResource>> list(
             alloc);
 
         EXPECT_TRUE(
@@ -2197,6 +2287,51 @@ TEST(ListTest, FrontBack)
     }
 }
 
+TEST(ListTest, Swap)
+{
+    {
+        rad::List<int> list1;
+        EXPECT_TRUE(
+            list1.AssignRange(std::initializer_list<int>{ 1, 2, 3, 4, 5 })
+                .IsOk());
+
+        rad::List<int> list2;
+        EXPECT_TRUE(
+            list2.AssignRange(std::initializer_list<int>{ 11, 12, 13, 14, 15 })
+                .IsOk());
+
+        list1.Swap(list2);
+        ListEqual(list1, { 11, 12, 13, 14, 15 });
+        ListEqual(list2, { 1, 2, 3, 4, 5 });
+    }
+    {
+        rad::List<int> list1;
+        EXPECT_TRUE(
+            list1.AssignRange(std::initializer_list<int>{ 1, 2, 3, 4, 5 })
+                .IsOk());
+
+        rad::List<int> list2;
+
+        list1.Swap(list2);
+        ListEqual(list1, {});
+        ListEqual(list2, { 1, 2, 3, 4, 5 });
+    }
+    {
+        rad::List<int> list1;
+        EXPECT_TRUE(
+            list1.AssignRange(std::initializer_list<int>{ 1, 2, 3, 4, 5 })
+                .IsOk());
+
+        list1.Swap(list1);
+        ListEqual(list1, { 1, 2, 3, 4, 5 });
+    }
+    {
+        rad::List<int> list1;
+        list1.Swap(list1);
+        ListEqual(list1, {});
+    }
+}
+
 TEST(ListTest, ReverseIterators)
 {
     {
@@ -2237,3 +2372,109 @@ TEST(ListTest, ReverseIterators)
         ListEqual(list2, { 5, 4, 3, 2, 1 });
     }
 }
+
+#ifdef RAD_GCC_VERSION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmultichar"
+#endif
+TEST(ListTest, TroubleAllocators)
+{
+    {
+        using StickyList = rad::List<int, radtest::StickyTaggedAllocator>;
+        StickyList list1(radtest::StickyTaggedAllocator{ 'tst1' });
+        EXPECT_TRUE(list1.PushBack(1).IsOk());
+
+        StickyList list2(std::move(list1));
+        EXPECT_TRUE(list1.Empty());
+        EXPECT_EQ(list1.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(list2.ExpensiveSize(), 1u);
+        EXPECT_EQ(list2.GetAllocator().m_tag, uint32_t('tst1'));
+
+        // These all static_assert, as they should
+        // list1 = std::move(list2);
+        // list1.Swap(list2);
+        // list1.SpliceAll(list1.end(), list2);
+        // list1.Clone();
+    }
+    {
+        using StickyDefaultList =
+            rad::List<int, radtest::StickyDefaultTaggedAllocator>;
+        StickyDefaultList list1(
+            radtest::StickyDefaultTaggedAllocator{ 'tst1' });
+        EXPECT_TRUE(list1.PushBack(1).IsOk());
+
+        StickyDefaultList list2(std::move(list1));
+        EXPECT_TRUE(list1.Empty());
+        EXPECT_EQ(list1.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(list2.ExpensiveSize(), 1u);
+        EXPECT_EQ(list2.GetAllocator().m_tag, uint32_t('tst1'));
+
+        auto expected_list3 = list2.Clone();
+        EXPECT_EQ(list2.ExpensiveSize(), 1u);
+        EXPECT_EQ(expected_list3.Ok().ExpensiveSize(), 1u);
+        EXPECT_EQ(expected_list3.Ok().GetAllocator().m_tag, uint32_t(1234));
+
+        // These all static_assert, as they should
+        // list1 = std::move(list2);
+        // list1.Swap(list2);
+        // list1.SpliceAll(list1.end(), list2);
+    }
+    {
+        using MovingList = rad::List<int, radtest::MovingTaggedAllocator>;
+        MovingList list1(radtest::MovingTaggedAllocator{ 'abcd' });
+        EXPECT_TRUE(list1.PushBack(1).IsOk());
+
+        MovingList list2(std::move(list1));
+        EXPECT_TRUE(list1.Empty());
+        EXPECT_EQ(list2.ExpensiveSize(), 1u);
+
+        auto expected_list3 = list2.Clone();
+        EXPECT_EQ(list2.ExpensiveSize(), 1u);
+        EXPECT_EQ(expected_list3.Ok().ExpensiveSize(), 1u);
+
+        MovingList list4(radtest::MovingTaggedAllocator{ 'wxyz' });
+        EXPECT_TRUE(list1.PushBack(99).IsOk());
+        list1.Swap(list4);
+        EXPECT_TRUE(list1.Empty());
+        EXPECT_EQ(list4.ExpensiveSize(), 1u);
+        EXPECT_EQ(list1.GetAllocator().m_tag, uint32_t('wxyz'));
+        EXPECT_EQ(list4.GetAllocator().m_tag, uint32_t('abcd'));
+
+        list1 = std::move(list4);
+        EXPECT_TRUE(list4.Empty());
+        EXPECT_EQ(list1.ExpensiveSize(), 1u);
+        EXPECT_EQ(list1.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(list4.GetAllocator().m_tag, uint32_t('abcd'));
+
+        // This static_asserts, as it should
+        // list1.SpliceAll(list1.end(), list2);
+    }
+    {
+        using TypedList = rad::List<int, radtest::TypedAllocator>;
+        TypedList list1;
+        EXPECT_TRUE(list1.PushBack(1).IsOk());
+
+        TypedList list2(std::move(list1));
+        EXPECT_TRUE(list1.Empty());
+        EXPECT_EQ(list2.ExpensiveSize(), 1u);
+
+        auto expected_list3 = list2.Clone();
+        EXPECT_EQ(list2.ExpensiveSize(), 1u);
+        EXPECT_EQ(expected_list3.Ok().ExpensiveSize(), 1u);
+
+        list1 = std::move(list2);
+        EXPECT_TRUE(list2.Empty());
+        EXPECT_EQ(list1.ExpensiveSize(), 1u);
+
+        list1.Swap(list2);
+        EXPECT_TRUE(list1.Empty());
+        EXPECT_EQ(list2.ExpensiveSize(), 1u);
+
+        list1.SpliceAll(list1.end(), list2);
+        EXPECT_TRUE(list2.Empty());
+        EXPECT_EQ(list1.ExpensiveSize(), 1u);
+    }
+}
+#ifdef RAD_GCC_VERSION
+#pragma GCC diagnostic pop
+#endif

--- a/test/test_Vector.cpp
+++ b/test/test_Vector.cpp
@@ -1001,7 +1001,7 @@ TEST_F(TestVectorIntegral, Move)
     EXPECT_EQ(other.Front(), 1);
     EXPECT_EQ(other.Back(), 3);
 
-#ifdef RAD_GCC_VERSION
+#if defined(RAD_GCC_VERSION) && RAD_GCC_VERSION >= 130000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
 #endif
@@ -1022,7 +1022,7 @@ TEST_F(TestVectorIntegral, Move)
 #ifdef RAD_CLANG_VERSION
 #pragma clang diagnostic pop
 #endif
-#ifdef RAD_GCC_VERSION
+#if defined(RAD_GCC_VERSION) && RAD_GCC_VERSION >= 130000
 #pragma GCC diagnostic pop
 #endif
 }

--- a/test/test_Vector.cpp
+++ b/test/test_Vector.cpp
@@ -19,7 +19,7 @@
 #define RAD_ENABLE_NOTHROW_DTOR_ASSERTIONS 0
 #define RAD_ENABLE_NOTHROW_MOVE_ASSERTIONS 0
 
-#define RAD_DEFAULT_ALLOCATOR radtest::Allocator
+#define RAD_DEFAULT_ALLOCATOR radtest::Mallocator
 
 #include "gtest/gtest.h"
 #include "test/TestAlloc.h"
@@ -241,8 +241,8 @@ TEST_F(TestVectorIntegral, InlineDefaultConstruct)
 
 TEST_F(TestVectorIntegral, AllocatorCopyConstruct)
 {
-    radtest::HeapAllocator heap;
-    radtest::AllocWrapper<int, radtest::HeapAllocator> alloc(heap);
+    radtest::HeapResource heap;
+    radtest::ResourceAllocator<radtest::HeapResource> alloc(heap);
     rad::Vector<int, decltype(alloc)> vec(alloc);
 
     EXPECT_TRUE(vec.Empty());
@@ -251,14 +251,14 @@ TEST_F(TestVectorIntegral, AllocatorCopyConstruct)
 
     EXPECT_EQ(heap.allocCount, 0);
     EXPECT_EQ(heap.freeCount, 0);
-    EXPECT_EQ(vec.GetAllocator().base, &heap);
+    EXPECT_EQ(vec.GetAllocator().m_res, &heap);
 }
 
 TEST_F(TestVectorIntegral, AllocatorMoveConstruct)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap> vec(heap);
 
     EXPECT_TRUE(vec.Empty());
@@ -267,14 +267,14 @@ TEST_F(TestVectorIntegral, AllocatorMoveConstruct)
 
     EXPECT_EQ(heap.allocCount, 0);
     EXPECT_EQ(heap.freeCount, 0);
-    EXPECT_EQ(vec.GetAllocator().base, &heap);
+    EXPECT_EQ(vec.GetAllocator().m_res, &heap);
 }
 
 TEST_F(TestVectorIntegral, Reserve)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap> vec(heap);
 
     EXPECT_TRUE(vec.Reserve(100).IsOk());
@@ -312,9 +312,9 @@ TEST_F(TestVectorIntegral, Reserve)
 
 TEST_F(TestVectorIntegral, InlineReserve)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::InlineVector<int, 10, AllocWrap> vec(heap);
 
     EXPECT_TRUE(vec.Reserve(5).IsOk());
@@ -368,9 +368,9 @@ TEST_F(TestVectorIntegral, InlineReserve)
 
 TEST_F(TestVectorIntegral, ReserveFail)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap> vec(heap);
 
     heap.forceAllocFails = 1;
@@ -385,9 +385,9 @@ TEST_F(TestVectorIntegral, ReserveFail)
 
 TEST_F(TestVectorIntegral, InlineReserveFail)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::InlineVector<int, 10, AllocWrap> vec(heap);
 
     heap.forceAllocFails = 1;
@@ -1000,6 +1000,31 @@ TEST_F(TestVectorIntegral, Move)
     EXPECT_EQ(other.Size(), 3u);
     EXPECT_EQ(other.Front(), 1);
     EXPECT_EQ(other.Back(), 3);
+
+#ifdef RAD_GCC_VERSION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+#endif
+#ifdef RAD_CLANG_VERSION
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+#endif
+
+    // self move assign
+    other = std::move(other);
+    EXPECT_EQ(other.Size(), 3u);
+    EXPECT_EQ(other.Front(), 1);
+    EXPECT_EQ(other.Back(), 3);
+
+    vec = std::move(vec);
+    EXPECT_EQ(vec.Size(), 0u);
+
+#ifdef RAD_CLANG_VERSION
+#pragma clang diagnostic pop
+#endif
+#ifdef RAD_GCC_VERSION
+#pragma GCC diagnostic pop
+#endif
 }
 
 TEST_F(TestVectorIntegral, Double)
@@ -1155,9 +1180,9 @@ TEST_F(TestVectorIntegral, ResizeSame)
 
 TEST_F(TestVectorIntegral, ShrinkToFitNoMemory)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap> vec(heap);
 
     EXPECT_TRUE(vec.Assign({ 1, 2, 3 }).IsOk());
@@ -1174,9 +1199,9 @@ TEST_F(TestVectorIntegral, ShrinkToFitNoMemory)
 
 TEST_F(TestVectorIntegral, InlineShrinkToFitNoMemory)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap, 1> vec(heap);
 
     EXPECT_TRUE(vec.Assign({ 1, 2, 3 }).IsOk());
@@ -1193,9 +1218,9 @@ TEST_F(TestVectorIntegral, InlineShrinkToFitNoMemory)
 
 TEST_F(TestVectorIntegral, CopyNoMemory)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap> vec(heap);
     rad::Vector<int, AllocWrap> other(heap);
 
@@ -1214,9 +1239,9 @@ TEST_F(TestVectorIntegral, CopyNoMemory)
 
 TEST_F(TestVectorIntegral, ResizeNoMemory)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap> vec(heap);
 
     heap.forceAllocFails = 1;
@@ -1234,9 +1259,9 @@ TEST_F(TestVectorIntegral, ResizeNoMemory)
 
 TEST_F(TestVectorIntegral, AssignNoMemory)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap> vec(heap);
 
     heap.forceAllocFails = 1;
@@ -1254,9 +1279,9 @@ TEST_F(TestVectorIntegral, AssignNoMemory)
 
 TEST_F(TestVectorIntegral, EmplaceBackNoMemory)
 {
-    using AllocWrap = radtest::AllocWrapper<int, radtest::HeapAllocator>;
+    using AllocWrap = radtest::ResourceAllocator<radtest::HeapResource>;
 
-    radtest::HeapAllocator heap;
+    radtest::HeapResource heap;
     rad::Vector<int, AllocWrap> vec(heap);
 
     heap.forceAllocFails = 1;
@@ -1463,9 +1488,8 @@ TYPED_TEST_P(NonTrivialStruct, Resize)
     EXPECT_EQ(g_stats.CopyAssignCount, 0);
     EXPECT_EQ(g_stats.MoveAssignCount, 0);
 
-    auto allocator =
-        radtest::OOMAllocator<TypeParam>(TypeParam::isNoThrow ? 1 : 3);
-    rad::Vector<TypeParam, radtest::OOMAllocator<TypeParam>> fail(allocator);
+    auto allocator = radtest::OOMAllocator(TypeParam::isNoThrow ? 1 : 3);
+    rad::Vector<TypeParam, radtest::OOMAllocator> fail(allocator);
     EXPECT_TRUE(fail.Resize(5, value).IsOk());
 
     EXPECT_EQ(fail.Resize(10, value), rad::Error::NoMemory);
@@ -1513,8 +1537,8 @@ TYPED_TEST_P(NonTrivialStruct, Assign)
     EXPECT_EQ(g_stats.CopyAssignCount, 0);
     EXPECT_EQ(g_stats.MoveAssignCount, 0);
 
-    rad::Vector<TypeParam, radtest::OOMAllocator<TypeParam>> fail(
-        radtest::OOMAllocator<TypeParam>(0));
+    rad::Vector<TypeParam, radtest::OOMAllocator> fail(
+        radtest::OOMAllocator(0));
     EXPECT_EQ(fail.Assign(10, value), rad::Error::NoMemory);
 }
 
@@ -1595,8 +1619,8 @@ TYPED_TEST_P(NonTrivialStruct, AssignSpan)
     EXPECT_EQ(g_stats.CopyAssignCount, 0);
     EXPECT_EQ(g_stats.MoveAssignCount, 0);
 
-    rad::Vector<TypeParam, radtest::OOMAllocator<TypeParam>> fail(
-        radtest::OOMAllocator<TypeParam>(0));
+    rad::Vector<TypeParam, radtest::OOMAllocator> fail(
+        radtest::OOMAllocator(0));
     EXPECT_EQ(fail.Assign(spanVec.ToSpan()), rad::Error::NoMemory);
 }
 
@@ -1724,12 +1748,12 @@ TYPED_TEST_P(NonTrivialStruct, Copy)
     EXPECT_EQ(g_stats.CopyAssignCount, 0);
     EXPECT_EQ(g_stats.MoveAssignCount, 0);
 
-    rad::Vector<TypeParam, radtest::OOMAllocator<TypeParam>> good(
-        radtest::OOMAllocator<TypeParam>(10));
+    rad::Vector<TypeParam, radtest::OOMAllocator> good(
+        radtest::OOMAllocator(10));
     EXPECT_TRUE(good.Assign(10, value).IsOk());
 
-    rad::Vector<TypeParam, radtest::OOMAllocator<TypeParam>> fail(
-        radtest::OOMAllocator<TypeParam>(0));
+    rad::Vector<TypeParam, radtest::OOMAllocator> fail(
+        radtest::OOMAllocator(0));
     EXPECT_EQ(good.Copy(fail), rad::Error::NoMemory);
 }
 
@@ -2373,3 +2397,255 @@ TEST_F(TestVectorStrongGuarantee, Copy)
     EXPECT_EQ(g_stats.CopyAssignCount, 0);
     EXPECT_EQ(g_stats.MoveAssignCount, 0);
 }
+
+#ifdef RAD_GCC_VERSION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmultichar"
+#endif
+TEST(VectorTest, TroubleAllocators)
+{
+    {
+        using StickyVec = rad::Vector<int, radtest::StickyTaggedAllocator>;
+        StickyVec vec1(radtest::StickyTaggedAllocator{ 'tst1' });
+        EXPECT_TRUE(vec1.PushBack(1).IsOk());
+
+        StickyVec vec2(rad::Move(vec1));
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec2.Size(), 1u);
+
+        StickyVec vec3(radtest::StickyTaggedAllocator{ 'tst3' });
+        EXPECT_TRUE(vec2.Copy(vec3).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(vec3.Size(), 1u);
+        EXPECT_EQ(vec3.GetAllocator().m_tag, uint32_t('tst3'));
+
+        StickyVec vec3a(radtest::StickyTaggedAllocator{ 'tst4' });
+        ASSERT_TRUE(vec3a.PushBack(42).IsOk());
+        ASSERT_TRUE(vec3a.PushBack(99).IsOk());
+        EXPECT_TRUE(vec2.Copy(vec3a).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(vec3a.Size(), 1u);
+        EXPECT_EQ(vec3a.GetAllocator().m_tag, uint32_t('tst4'));
+
+        // These all static_assert, as they should
+        // vec1 = std::move(vec2);
+        // vec1.Swap(vec2);
+        // vec1.Move(vec2);
+        // vec1.Clone();
+    }
+    {
+        using StickyVecNt =
+            rad::Vector<ThrowingVecTester, radtest::StickyTaggedAllocator>;
+        StickyVecNt vec1(radtest::StickyTaggedAllocator{ 'tst1' });
+        EXPECT_TRUE(vec1.PushBack(ThrowingVecTester(1)).IsOk());
+
+        StickyVecNt vec2(rad::Move(vec1));
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec2.Size(), 1u);
+
+        StickyVecNt vec3(radtest::StickyTaggedAllocator{ 'tst3' });
+        EXPECT_TRUE(vec2.Copy(vec3).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(vec3.Size(), 1u);
+        EXPECT_EQ(vec3.GetAllocator().m_tag, uint32_t('tst3'));
+
+        StickyVecNt vec3a(radtest::StickyTaggedAllocator{ 'tst4' });
+        ASSERT_TRUE(vec3a.PushBack(ThrowingVecTester(42)).IsOk());
+        ASSERT_TRUE(vec3a.PushBack(ThrowingVecTester(99)).IsOk());
+        EXPECT_TRUE(vec2.Copy(vec3a).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(vec3a.Size(), 1u);
+        EXPECT_EQ(vec3a.GetAllocator().m_tag, uint32_t('tst4'));
+
+        // These all static_assert, as they should
+        // vec1 = std::move(vec2);
+        // vec1.Swap(vec2);
+        // vec1.Move(vec2);
+        // vec1.Clone();
+    }
+    {
+        using StickyDefaultVec =
+            rad::Vector<int, radtest::StickyDefaultTaggedAllocator>;
+        StickyDefaultVec vec1(radtest::StickyDefaultTaggedAllocator{ 'tst1' });
+        EXPECT_TRUE(vec1.PushBack(1).IsOk());
+
+        StickyDefaultVec vec2(std::move(vec1));
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec1.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('tst1'));
+
+        StickyDefaultVec vec3(radtest::StickyDefaultTaggedAllocator{ 'tst3' });
+        EXPECT_TRUE(vec2.Copy(vec3).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(vec3.Size(), 1u);
+        EXPECT_EQ(vec3.GetAllocator().m_tag, uint32_t('tst3'));
+
+        StickyDefaultVec vec3a(radtest::StickyDefaultTaggedAllocator{ 'tst4' });
+        ASSERT_TRUE(vec3a.PushBack(42).IsOk());
+        ASSERT_TRUE(vec3a.PushBack(99).IsOk());
+        EXPECT_TRUE(vec2.Copy(vec3a).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('tst1'));
+        EXPECT_EQ(vec3a.Size(), 1u);
+        EXPECT_EQ(vec3a.GetAllocator().m_tag, uint32_t('tst4'));
+
+        auto expected_vec4 = vec2.Clone();
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(expected_vec4.Ok().Size(), 1u);
+        EXPECT_EQ(expected_vec4.Ok().GetAllocator().m_tag, uint32_t(1234));
+
+        // These all static_assert, as they should
+        // vec1 = std::move(vec2);
+        // vec1.Swap(vec2);
+        // vec1.Move(vec2);
+    }
+
+    {
+        using MovingVec = rad::Vector<int, radtest::MovingTaggedAllocator>;
+        MovingVec vec1(radtest::MovingTaggedAllocator{ 'abcd' });
+        EXPECT_TRUE(vec1.PushBack(1).IsOk());
+
+        MovingVec vec2(rad::Move(vec1));
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec2.Size(), 1u);
+
+        MovingVec vec3(radtest::MovingTaggedAllocator{ 'tst3' });
+        EXPECT_TRUE(vec2.Copy(vec3).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(vec3.Size(), 1u);
+        EXPECT_EQ(vec3.GetAllocator().m_tag, uint32_t('abcd'));
+
+        MovingVec vec3a(radtest::MovingTaggedAllocator{ 'tst4' });
+        ASSERT_TRUE(vec3a.PushBack(42).IsOk());
+        ASSERT_TRUE(vec3a.PushBack(99).IsOk());
+        EXPECT_TRUE(vec2.Copy(vec3a).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(vec3a.Size(), 1u);
+        EXPECT_EQ(vec3a.GetAllocator().m_tag, uint32_t('abcd'));
+
+        MovingVec vec4(radtest::MovingTaggedAllocator{ 'wxyz' });
+        EXPECT_TRUE(vec1.PushBack(99).IsOk());
+        vec1.Swap(vec4);
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec4.Size(), 1u);
+        EXPECT_EQ(vec1.GetAllocator().m_tag, uint32_t('wxyz'));
+        EXPECT_EQ(vec4.GetAllocator().m_tag, uint32_t('abcd'));
+
+        vec1 = rad::Move(vec4);
+        EXPECT_TRUE(vec4.Empty());
+        EXPECT_EQ(vec1.Size(), 1u);
+        EXPECT_EQ(vec1.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(vec4.GetAllocator().m_tag, uint32_t('abcd'));
+
+        MovingVec vec5(radtest::MovingTaggedAllocator{ 'crwd' });
+        vec1.Move(vec5);
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec5.Size(), 1u);
+        EXPECT_EQ(vec1.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(vec5.GetAllocator().m_tag, uint32_t('abcd'));
+    }
+    {
+        using MovingVecNt =
+            rad::Vector<ThrowingVecTester, radtest::MovingTaggedAllocator>;
+        MovingVecNt vec1(radtest::MovingTaggedAllocator{ 'abcd' });
+        EXPECT_TRUE(vec1.PushBack(ThrowingVecTester(1)).IsOk());
+
+        MovingVecNt vec2(rad::Move(vec1));
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec2.Size(), 1u);
+
+        MovingVecNt vec3(radtest::MovingTaggedAllocator{ 'tst3' });
+        EXPECT_TRUE(vec2.Copy(vec3).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(vec3.Size(), 1u);
+        EXPECT_EQ(vec3.GetAllocator().m_tag, uint32_t('abcd'));
+
+        MovingVecNt vec3a(radtest::MovingTaggedAllocator{ 'tst4' });
+        ASSERT_TRUE(vec3a.PushBack(ThrowingVecTester(42)).IsOk());
+        ASSERT_TRUE(vec3a.PushBack(ThrowingVecTester(99)).IsOk());
+        EXPECT_TRUE(vec2.Copy(vec3a).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec2.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(vec3a.Size(), 1u);
+        EXPECT_EQ(vec3a.GetAllocator().m_tag, uint32_t('abcd'));
+
+        MovingVecNt vec4(radtest::MovingTaggedAllocator{ 'wxyz' });
+        EXPECT_TRUE(vec1.PushBack(ThrowingVecTester(99)).IsOk());
+        vec1.Swap(vec4);
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec4.Size(), 1u);
+        EXPECT_EQ(vec1.GetAllocator().m_tag, uint32_t('wxyz'));
+        EXPECT_EQ(vec4.GetAllocator().m_tag, uint32_t('abcd'));
+
+        vec1 = rad::Move(vec4);
+        EXPECT_TRUE(vec4.Empty());
+        EXPECT_EQ(vec1.Size(), 1u);
+        EXPECT_EQ(vec1.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(vec4.GetAllocator().m_tag, uint32_t('abcd'));
+
+        MovingVecNt vec5(radtest::MovingTaggedAllocator{ 'crwd' });
+        vec1.Move(vec5);
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec5.Size(), 1u);
+        EXPECT_EQ(vec1.GetAllocator().m_tag, uint32_t('abcd'));
+        EXPECT_EQ(vec5.GetAllocator().m_tag, uint32_t('abcd'));
+    }
+
+    {
+        using TypedVec = rad::Vector<int, radtest::TypedAllocator>;
+        TypedVec vec1;
+        EXPECT_TRUE(vec1.PushBack(1).IsOk());
+
+        TypedVec vec2(rad::Move(vec1));
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec2.Size(), 1u);
+
+        TypedVec vec3;
+        EXPECT_TRUE(vec2.Copy(vec3).IsOk());
+        EXPECT_EQ(vec2.Size(), 1u);
+        EXPECT_EQ(vec3.Size(), 1u);
+
+        vec1 = rad::Move(vec2);
+        EXPECT_TRUE(vec2.Empty());
+        EXPECT_EQ(vec1.Size(), 1u);
+
+        vec1.Swap(vec2);
+        EXPECT_TRUE(vec1.Empty());
+        EXPECT_EQ(vec2.Size(), 1u);
+
+        TypedVec vec4;
+        vec2.Move(vec4);
+        EXPECT_TRUE(vec2.Empty());
+        EXPECT_EQ(vec4.Size(), 1u);
+    }
+
+    {
+        int value = 42;
+        rad::Vector<int, radtest::MoveOOMAllocator> good(
+            radtest::MoveOOMAllocator(1, 1234)); // you get one good allocation
+        EXPECT_TRUE(good.Assign(10, value).IsOk());
+
+        rad::Vector<int, radtest::MoveOOMAllocator> fail(
+            radtest::MoveOOMAllocator(99, 5678)); // not ever used
+        EXPECT_EQ(good.Copy(fail), rad::Error::NoMemory);
+        EXPECT_EQ(fail.GetAllocator().m_id, 5678);
+
+        rad::Vector<int, radtest::MoveOOMAllocator> pass(
+            radtest::MoveOOMAllocator(99, 5678));
+        EXPECT_TRUE(pass.Assign(10, value).IsOk());
+        EXPECT_TRUE(pass.Copy(good).IsOk());
+        EXPECT_EQ(good.GetAllocator().m_id, 5678);
+    }
+}
+#ifdef RAD_GCC_VERSION
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Switch to an allocator model similar to the STL. This required updating List, Vector, and SharedPtr, the current allocator clients.

Users of allocators should generally indirect their operations through AllocTraits. This allows user-provided allocators to provide a minimal set of basis operations (AllocBytes + FreeBytes, or Alloc + Free), while letting the remainder of the operations to be given sane defaults. This PR's approach to allocators deviates from the STL, in that allocator types aren't required to be templated on the value type. This makes allocator implementations more approachable, avoids the need to rebind, and can even help build throughput due to fewer template instantiations.

This PR also provides StdAllocator, a radiant allocator that forwards to std::allocator. This both provides an example of an allocator with all the features turned on, as well as provide the path to constexpr containers, if we want to go down that path. There are multiple test allocators (like Mallocator) that demonstrate the minimal interface.

There are some drive-by fixes / changes to List and Vector. There were missing self-assignment / self-splicing checks before hand. Vector also didn't have a move ctor, but did have an allocator move ctor. Also I fixed one of the many FalseTypes.

Useful background reading on implementing allocators: https://thephd.dev/allocator-hell-small_bit_vector .