### PR TITLE
Feat/unique ptr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Please read the [Code of Conduct](CODE_OF_CONDUCT.md).
 * Radiant uses Bazel as the primary build system. Install Bazel
   ([official instructions][bazel.install]). [Bazelisk][bazel.bazelisk] is
   recommended.
-* Python is required for tooling. Install Python
+* Python (3.11+) is required for tooling. Install Python
   ([official instructions][python.install]).
 * Radiant uses python package to aid in the remaining setup and subsequent
   workflows. Install it into your python environment by running:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ additional information or guidance.
 
 ## Disclosure Policy
 
-When the Radiant team receives a security bug report, they will assign it to a
+When the Raditn team receives a security bug report, they will assign it to a
 primary developer. This person will coordinate the fix and release process,
 involving the following steps:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ additional information or guidance.
 
 ## Disclosure Policy
 
-When the Raditn team receives a security bug report, they will assign it to a
+When the Radiant team receives a security bug report, they will assign it to a
 primary developer. This person will coordinate the fix and release process,
 involving the following steps:
 

--- a/radiant/UniquePtr.h
+++ b/radiant/UniquePtr.h
@@ -1,11 +1,9 @@
+// radiant/UniquePtr.h
 // Copyright 2025 The Radiant Authors.
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,41 +14,52 @@
 
 #include "radiant/TotallyRad.h"
 #include "radiant/TypeTraits.h"
-#include "radiant/Utility.h" // NOLINT(misc-include-cleaner)
-#include "radiant/Memory.h"
+#include "radiant/Utility.h"   // for rad::swap overload
+#include <utility>             // std::move
+#include <cstddef>             // nullptr_t
+#include <algorithm>           // std::swap
 
 namespace rad
 {
-template <typename T, typename Deleter = DefaultDelete<T>>
 
+// Empty deleter type so it occupies no storage (EBO).
+template <typename T>
+struct DefaultDelete {
+    constexpr DefaultDelete() noexcept = default;
+    void operator()(T* p) const noexcept { delete p; }
+};
+
+// UniquePtr<T, Deleter> owns a T* and invokes Deleter when destroyed.
+// If Deleter is empty, sizeof(UniquePtr) == sizeof(T*).
+template <typename T, typename Deleter = DefaultDelete<T>>
 class UniquePtr : private Deleter
 {
 public:
     RAD_NOT_COPYABLE(UniquePtr);
 
     using pointer      = T*;
+    using deleter_type = Deleter;
 
-    struct DefaultDelete
-    {
-        constexpr DefaultDelete() noexcept = default;
-        void operator()(T* p) const noexcept { delete p; }
-    };
-
+    /// @brief Default constructs to nullptr.
     constexpr UniquePtr() noexcept
-      : Deleter(), // empty base
+      : Deleter(),  // base subobject
         m_ptr(nullptr)
     {}
 
-    explicit constexpr UniquePtr(pointer p, Deleter d = Deleter()) noexcept
+    /// @brief Constructs owning a raw pointer + optional custom deleter.
+    explicit constexpr UniquePtr(pointer p,
+                                 Deleter d = Deleter()) noexcept
       : Deleter(std::move(d)),
         m_ptr(p)
     {}
 
+    /// @brief Destroys the managed object if non-null.
     ~UniquePtr() noexcept
     {
         if (m_ptr) static_cast<Deleter&>(*this)(m_ptr);
     }
 
+    /// @brief Move-constructs, stealing ownership.
     constexpr UniquePtr(UniquePtr&& o) noexcept
       : Deleter(std::move(o.get_deleter())),
         m_ptr(o.m_ptr)
@@ -58,6 +67,7 @@ public:
         o.m_ptr = nullptr;
     }
 
+    /// @brief Move-assigns, destroying current and stealing ownership.
     UniquePtr& operator=(UniquePtr&& o) noexcept
     {
         if (this != &o)
@@ -71,12 +81,22 @@ public:
     }
 
     // observers
-    constexpr pointer get() const noexcept          { return m_ptr; }
-    constexpr T&      operator*()  const noexcept   { return *m_ptr; }
-    constexpr pointer operator->() const noexcept   { return m_ptr; }
+
+    /// @return the stored pointer (may be nullptr)
+    constexpr pointer get() const noexcept { return m_ptr; }
+
+    /// @return reference to *get()
+    constexpr T& operator*() const noexcept { return *m_ptr; }
+
+    /// @return get(), for pointer‐like syntax
+    constexpr pointer operator->() const noexcept { return m_ptr; }
+
+    /// @return true if get() != nullptr
     explicit constexpr operator bool() const noexcept { return m_ptr != nullptr; }
 
     // modifiers
+
+    /// @brief Release ownership without deleting; returns previous pointer.
     pointer release() noexcept
     {
         pointer tmp = m_ptr;
@@ -84,28 +104,37 @@ public:
         return tmp;
     }
 
+    /// @brief Delete current and take new pointer p (default nullptr)
     void reset(pointer p = nullptr) noexcept
     {
         if (m_ptr) static_cast<Deleter&>(*this)(m_ptr);
         m_ptr = p;
     }
 
-    /// @brief Swaps the contents of this unique pointer with another.
-    /// @details This is a no-op if the pointers are the same.
-    /// @param o
+    /// @brief Swap pointers and deleters with another UniquePtr
     void swap(UniquePtr& o) noexcept
     {
-        rad::Swap(m_ptr, o.m_ptr);
-        rad::Swap(get_deleter(), o.get_deleter());
+        using std::swap;
+        swap(m_ptr, o.m_ptr);
+        swap(get_deleter(), o.get_deleter());
     }
 
-    constexpr Deleter&       get_deleter() noexcept { return m_del; }
-    constexpr const Deleter& get_deleter() const noexcept { return m_del; }
+    /// @return reference to the stored deleter
+    constexpr Deleter&       get_deleter() noexcept       { return static_cast<Deleter&>(*this); }
+    constexpr const Deleter& get_deleter() const noexcept { return static_cast<const Deleter&>(*this); }
 
 private:
     pointer m_ptr;
 };
 
+/// @brief ADL‐enabled swap overload
+template <typename T, typename D>
+void swap(UniquePtr<T, D>& a, UniquePtr<T, D>& b) noexcept
+{
+    a.swap(b);
+}
+
+/// @brief Alias using default deleter
 template <typename T>
 using UniquePtrDefault = UniquePtr<T>;
 

--- a/radiant/UniquePtr.h
+++ b/radiant/UniquePtr.h
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#include "radiant/TotallyRad.h"
-#include "radiant/TypeTraits.h"
 #include "radiant/Utility.h"                // rad::Move
 #include "radiant/Algorithm.h"              // rad::Swap
 #include "radiant/detail/StdTypeTraits.h"   // rad::IsConv
@@ -27,7 +25,7 @@ template <typename T>
 struct DefaultDelete {
     constexpr DefaultDelete() noexcept = default;
 
-    // Allow DefaultDelete<Base> to be constructed from DefaultDelete<Derived>
+    /// @brief Allow DefaultDelete<Base> to be constructed from DefaultDelete<Derived>
     template <typename U,
               rad::EnIf<rad::IsConv<U*, T*>, int> = 0>
     constexpr DefaultDelete(const DefaultDelete<U>&) noexcept {}
@@ -35,8 +33,8 @@ struct DefaultDelete {
     void operator()(T* p) const noexcept { delete p; }
 };
 
-// UniquePtr<T, Deleter> owns a T* and invokes Deleter when destroyed.
-// If Deleter is empty, sizeof(UniquePtr) == sizeof(T*).
+/// @brief UniquePtr<T, Deleter> owns a T* and invokes Deleter when destroyed.
+/// @details If Deleter is empty, sizeof(UniquePtr) == sizeof(T*).
 template <typename T, typename Deleter = DefaultDelete<T>>
 class UniquePtr : private Deleter
 {

--- a/radiant/UniquePtr.h
+++ b/radiant/UniquePtr.h
@@ -1,0 +1,134 @@
+// Copyright 2025 The Radiant Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "radiant/TotallyRad.h"
+#include "radiant/TypeTraits.h"
+#include "radiant/Utility.h" // NOLINT(misc-include-cleaner)
+#include "radiant/Memory.h"
+
+namespace rad
+{
+/// @brief Exclusive ownership smart pointer analog.
+/// @details A move-only pointer wrapper that manages a single, heap-allocated
+/// object of type T, ensuring lifetime-based destruction without relying on
+/// external allocators or additional storage beyond one pointer.
+/// @tparam T the type of the object being owned.
+
+template <typename T, typename Deleter = void(*) (T*)>
+class UniquePtr
+{
+public:
+    RAD_NOT_COPYABLE(UniquePtr);
+
+    /// @brief Default deleter: plain delete.
+    static void DefaultDeleter(T* ptr) noexcept { delete ptr; }
+
+    using pointer      = T*;
+    using deleter_type = Deleter;
+
+    /// @brief Default constructs to nullptr.
+    /// @details ctor is constexpr to allow for static initialization,
+    /// dtor is not constexpr to allow for custom deleters.
+    constexpr UniquePtr() noexcept
+      : m_ptr(nullptr), 
+        m_del(Deleter(DefaultDeleter))
+    {}
+
+    /// @brief Constructs owning a raw pointer.
+    /// @param p 
+    /// @param d 
+    explicit constexpr UniquePtr(pointer p,
+                                 Deleter d = Deleter(DefaultDeleter)) noexcept
+      : m_ptr(p),
+        m_del(p)
+    {}
+
+    /// @brief Constructs from a raw pointer.
+    /// @details This constructor is constexpr to allow for static initialization.
+    /// @param p the raw pointer to take ownership of.
+    /// @param d the deleter to use for destruction.
+    /// @param alloc the allocator to use for allocation.
+    /// @param tag the tag to use for allocation.
+    /// @param size the size of the object to allocate.
+    /// @param alignment the alignment of the object to allocate.
+    /// @param args the arguments to pass to the constructor of the object.
+    ~UniquePtr() noexcept
+    {
+        if (m_ptr) m_del(m_ptr);
+    }
+
+    /// @brief Move ownership of object.
+    /// @details
+    constexpr UniquePtr(UniquePtr&& o) noexcept
+      : m_ptr(o.m_ptr),
+        m_del(o.m_del)
+    {
+        o.m_ptr = nullptr;
+    }
+
+    UniquePtr& operator=(UniquePtr&& o) noexcept
+    {
+        if (this != &o)
+        {
+            if (m_ptr) m_del(m_ptr);
+            m_ptr = o.m_ptr;
+            m_del = o.m_del;
+            o.m_ptr = nullptr;
+        }
+        return *this;
+    }
+
+    // observers
+    constexpr pointer get() const noexcept          { return m_ptr; }
+    constexpr T&      operator*()  const noexcept   { return *m_ptr; }
+    constexpr pointer operator->() const noexcept   { return m_ptr; }
+    explicit constexpr operator bool() const noexcept { return m_ptr != nullptr; }
+
+    // modifiers
+    pointer release() noexcept
+    {
+        pointer tmp = m_ptr;
+        m_ptr = nullptr;
+        return tmp;
+    }
+
+    void reset(pointer p = nullptr) noexcept
+    {
+        if (m_ptr) m_del(m_ptr);
+        m_ptr = p;
+    }
+
+    /// @brief Swaps the contents of this unique pointer with another.
+    /// @details This is a no-op if the pointers are the same.
+    /// @param o
+    void swap(UniquePtr& o) noexcept
+    {
+        rad::Swap(m_ptr, o.m_ptr);
+        rad::Swap(m_del, o.m_del);
+    }
+
+    constexpr Deleter&       get_deleter() noexcept { return m_del; }
+    constexpr const Deleter& get_deleter() const noexcept { return m_del; }
+
+private:
+    pointer m_ptr;
+    Deleter m_del;
+};
+
+template <typename T>
+using UniquePtrDefault = UniquePtr<T, void(*) (T*)>;
+
+} // namespace rad

--- a/radiant/UniquePtr.h
+++ b/radiant/UniquePtr.h
@@ -14,11 +14,10 @@
 
 #include "radiant/TotallyRad.h"
 #include "radiant/TypeTraits.h"
-#include "radiant/Utility.h"   // for rad::swap overload
-#include "radiant/detail/StdTypeTraits.h"
-#include <utility>             // std::move
-#include <cstddef>             // nullptr_t
-#include <algorithm>           // std::swap
+#include "radiant/Utility.h"                // rad::Move
+#include "radiant/Algorithm.h"              // rad::Swap
+#include "radiant/detail/StdTypeTraits.h"   // rad::IsConv
+#include <cstddef>                          // nullptr_t
 
 namespace rad
 {
@@ -55,7 +54,7 @@ public:
 
     /// @brief Constructs owning a raw pointer + optional custom deleter.
     explicit constexpr UniquePtr(pointer p, Deleter d = Deleter()) noexcept
-      : Deleter(std::move(d)),
+      : Deleter(rad::Move(d)),
         m_ptr(p)
     {}
 
@@ -63,13 +62,13 @@ public:
     template <class U, class E,
               rad::EnIf<rad::IsConv<U*, T*>, int> = 0>
     constexpr UniquePtr(UniquePtr<U, E>&& o) noexcept
-      : Deleter(std::move(o.get_deleter())),
+      : Deleter(rad::Move(o.get_deleter())),
         m_ptr(o.release())
     {}
 
     /// @brief Move-constructs, stealing ownership
     constexpr UniquePtr(UniquePtr&& o) noexcept
-      : Deleter(std::move(o.get_deleter())),
+      : Deleter(rad::Move(o.get_deleter())),
         m_ptr(o.release())
     {
         o.m_ptr = nullptr;
@@ -94,7 +93,7 @@ public:
     UniquePtr& operator=(UniquePtr<U, E>&& o) noexcept
     {
         reset(o.release());
-        get_deleter() = std::move(o.get_deleter());
+        get_deleter() = rad::Move(o.get_deleter());
         return *this;
     }
 
@@ -105,7 +104,7 @@ public:
         {
             reset();
             m_ptr = o.m_ptr;
-            get_deleter() = std::move(o.get_deleter());
+            get_deleter() = rad::Move(o.get_deleter());
             o.m_ptr = nullptr;
         }
         return *this;
@@ -145,9 +144,9 @@ public:
     /// @brief Swap pointers and deleters with another UniquePtr
     void swap(UniquePtr& o) noexcept
     {
-        using rad::swap;
-        swap(m_ptr, o.m_ptr);
-        swap(get_deleter(), o.get_deleter());
+        using rad::Swap;
+        Swap(m_ptr, o.m_ptr);
+        Swap(get_deleter(), o.get_deleter());
     }
 
     /// @return reference to the stored deleter

--- a/radiant/UniquePtr.h
+++ b/radiant/UniquePtr.h
@@ -145,7 +145,7 @@ public:
     /// @brief Swap pointers and deleters with another UniquePtr
     void swap(UniquePtr& o) noexcept
     {
-        using std::swap;
+        using rad::swap;
         swap(m_ptr, o.m_ptr);
         swap(get_deleter(), o.get_deleter());
     }

--- a/test/test_UniquePtr.cpp
+++ b/test/test_UniquePtr.cpp
@@ -48,6 +48,13 @@ TEST(UniquePtr, BasicLifetimeAndSize) {
   EXPECT_EQ(Foo::live, 0);
 }
 
+TEST (UniquePtr, NullptrAssignment) {
+  rad::UniquePtrDefault<int> p(new int{3});
+  EXPECT_TRUE(p);
+  p = nullptr;
+  EXPECT_FALSE(p);
+}
+
 TEST(UniquePtr, ReleaseAndReset) {
   Foo::live = 0;
   Foo* raw = new Foo{7};
@@ -95,6 +102,21 @@ TEST(UniquePtr, MoveSemantics) {
   // cleanup
   c.reset();
   EXPECT_EQ(Foo::live, 0);
+}
+
+struct Base { virtual ~Base() = default; };
+struct Derived : Base { int v = 9; };
+
+TEST(UniquePtr, ConvertingMove) {
+  rad::UniquePtr<Derived> d(new Derived{});
+  rad::UniquePtr<Base>    b(std::move(d));
+  EXPECT_TRUE(b);
+  EXPECT_FALSE(d);
+
+  rad::UniquePtr<Derived> d2(new Derived{});
+  b = std::move(d2);
+  EXPECT_TRUE(b);
+  EXPECT_FALSE(d2);
 }
 
 TEST(UniquePtr, Swap) {

--- a/test/test_UniquePtr.cpp
+++ b/test/test_UniquePtr.cpp
@@ -1,0 +1,126 @@
+// test/test_UniquePtr.cpp
+// Copyright 2025 The Radiant Authors.
+// Licensed under the Apache License, Version 2.0 (the "License"); …
+
+#include "gtest/gtest.h"
+#include "radiant/UniquePtr.h"
+
+namespace rad {
+  // convenience alias for tests
+  template <typename T>
+  using UniquePtrDefault = UniquePtr<T, void(*)(T*)>;
+}
+
+struct Foo {
+  static int live;
+  int value;
+  Foo(int v) : value(v) { ++live; }
+  ~Foo() { --live; }
+};
+int Foo::live = 0;
+
+TEST(UniquePtr, BasicLifetimeAndSize) {
+  static_assert(sizeof(rad::UniquePtrDefault<Foo>) == sizeof(Foo*),
+                "UniquePtrDefault<Foo> must be one pointer in size");
+  
+  EXPECT_EQ(Foo::live, 0);
+  {
+    rad::UniquePtrDefault<Foo> p(new Foo{42});
+    EXPECT_TRUE(p);
+    EXPECT_EQ(p->value, 42);
+    EXPECT_EQ(Foo::live, 1);
+  }
+  // destructor should have run
+  EXPECT_EQ(Foo::live, 0);
+}
+
+TEST(UniquePtr, ReleaseAndReset) {
+  Foo::live = 0;
+  Foo* raw = new Foo{7};
+  rad::UniquePtrDefault<Foo> p(raw);
+  EXPECT_TRUE(p);
+  EXPECT_EQ(Foo::live, 1);
+
+  Foo* r = p.release();
+  EXPECT_EQ(r, raw);
+  EXPECT_FALSE(p);
+  // user must delete now:
+  delete r;
+  EXPECT_EQ(Foo::live, 0);
+
+  // reset to new object
+  p.reset(new Foo{5});
+  EXPECT_TRUE(p);
+  EXPECT_EQ(p->value, 5);
+  EXPECT_EQ(Foo::live, 1);
+  // reset to nullptr
+  p.reset();
+  EXPECT_FALSE(p);
+  EXPECT_EQ(Foo::live, 0);
+}
+
+TEST(UniquePtr, MoveSemantics) {
+  Foo::live = 0;
+  rad::UniquePtrDefault<Foo> a(new Foo{1});
+  EXPECT_TRUE(a);
+  rad::UniquePtrDefault<Foo> b(std::move(a));
+  EXPECT_FALSE(a);
+  EXPECT_TRUE(b);
+  EXPECT_EQ(b->value, 1);
+
+  // move‐assign
+  Foo::live = 1;
+  rad::UniquePtrDefault<Foo> c;
+  c = std::move(b);
+  EXPECT_FALSE(b);
+  EXPECT_TRUE(c);
+  EXPECT_EQ(c->value, 1);
+  // cleanup
+  c.reset();
+  EXPECT_EQ(Foo::live, 0);
+}
+
+TEST(UniquePtr, Swap) {
+  Foo::live = 0;
+  rad::UniquePtrDefault<Foo> x(new Foo{10});
+  rad::UniquePtrDefault<Foo> y(new Foo{20});
+  EXPECT_EQ(x->value, 10);
+  EXPECT_EQ(y->value, 20);
+
+  x.swap(y);
+  EXPECT_EQ(x->value, 20);
+  EXPECT_EQ(y->value, 10);
+
+  using std::swap;
+  swap(x, y);
+  EXPECT_EQ(x->value, 10);
+  EXPECT_EQ(y->value, 20);
+
+  // clean up
+  x.reset();
+  y.reset();
+  EXPECT_EQ(Foo::live, 0);
+}
+
+TEST(UniquePtr, CustomDeleter) {
+  struct D {
+    static int count;
+    static void del(int* p) noexcept {
+      ++count;
+      ::delete p;
+    }
+  };
+  int* raw = new int(99);
+  static_assert(!std::is_same_v<decltype(D::del), void(*)(int*)> ||
+                sizeof(rad::UniquePtr<int, decltype(&D::del)>) == sizeof(int*),
+                "still one-pointer");
+
+  rad::UniquePtr<int, decltype(&D::del)> p(raw, &D::del);
+  EXPECT_EQ(*p, 99);
+  EXPECT_EQ(D::count, 0);
+
+  p.reset();
+  EXPECT_EQ(D::count, 1);
+  EXPECT_FALSE(p);
+}
+int D::count = 0;

--- a/test/test_UniquePtr.cpp
+++ b/test/test_UniquePtr.cpp
@@ -1,6 +1,14 @@
 // test/test_UniquePtr.cpp
 // Copyright 2025 The Radiant Authors.
-// Licensed under the Apache License, Version 2.0 (the "License"); …
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "gtest/gtest.h"
 #include "radiant/UniquePtr.h"

--- a/test/test_UniquePtr.cpp
+++ b/test/test_UniquePtr.cpp
@@ -5,24 +5,30 @@
 #include "gtest/gtest.h"
 #include "radiant/UniquePtr.h"
 
-namespace rad {
-  // convenience alias for tests
-  template <typename T>
-  using UniquePtrDefault = UniquePtr<T, void(*)(T*)>;
-}
-
+// simple type to track live instances
 struct Foo {
   static int live;
   int value;
   Foo(int v) : value(v) { ++live; }
-  ~Foo() { --live; }
+  ~Foo()         { --live; }
 };
 int Foo::live = 0;
 
+// custom deleter functor for testing
+struct D {
+  static int count;
+  void operator()(int* p) const noexcept {
+    ++count;
+    delete p;
+  }
+};
+int D::count = 0;
+
 TEST(UniquePtr, BasicLifetimeAndSize) {
+  // the default deleter is empty, so this must be one pointer in size
   static_assert(sizeof(rad::UniquePtrDefault<Foo>) == sizeof(Foo*),
-                "UniquePtrDefault<Foo> must be one pointer in size");
-  
+                "UniquePtrDefault<Foo> must be one pointer");
+
   EXPECT_EQ(Foo::live, 0);
   {
     rad::UniquePtrDefault<Foo> p(new Foo{42});
@@ -53,6 +59,7 @@ TEST(UniquePtr, ReleaseAndReset) {
   EXPECT_TRUE(p);
   EXPECT_EQ(p->value, 5);
   EXPECT_EQ(Foo::live, 1);
+
   // reset to nullptr
   p.reset();
   EXPECT_FALSE(p);
@@ -63,18 +70,20 @@ TEST(UniquePtr, MoveSemantics) {
   Foo::live = 0;
   rad::UniquePtrDefault<Foo> a(new Foo{1});
   EXPECT_TRUE(a);
+
   rad::UniquePtrDefault<Foo> b(std::move(a));
   EXPECT_FALSE(a);
   EXPECT_TRUE(b);
   EXPECT_EQ(b->value, 1);
 
-  // move‐assign
+  // move-assign
   Foo::live = 1;
   rad::UniquePtrDefault<Foo> c;
   c = std::move(b);
   EXPECT_FALSE(b);
   EXPECT_TRUE(c);
   EXPECT_EQ(c->value, 1);
+
   // cleanup
   c.reset();
   EXPECT_EQ(Foo::live, 0);
@@ -91,36 +100,29 @@ TEST(UniquePtr, Swap) {
   EXPECT_EQ(x->value, 20);
   EXPECT_EQ(y->value, 10);
 
+  // ADL swap
   using std::swap;
   swap(x, y);
   EXPECT_EQ(x->value, 10);
   EXPECT_EQ(y->value, 20);
 
-  // clean up
+  // cleanup
   x.reset();
   y.reset();
   EXPECT_EQ(Foo::live, 0);
 }
 
 TEST(UniquePtr, CustomDeleter) {
-  struct D {
-    static int count;
-    static void del(int* p) noexcept {
-      ++count;
-      ::delete p;
-    }
-  };
+  D::count = 0;
   int* raw = new int(99);
-  static_assert(!std::is_same_v<decltype(D::del), void(*)(int*)> ||
-                sizeof(rad::UniquePtr<int, decltype(&D::del)>) == sizeof(int*),
-                "still one-pointer");
 
-  rad::UniquePtr<int, decltype(&D::del)> p(raw, &D::del);
+  // UniquePtr<int, D> uses our functor D
+  rad::UniquePtr<int, D> p(raw, D());
+  EXPECT_TRUE(p);
   EXPECT_EQ(*p, 99);
   EXPECT_EQ(D::count, 0);
 
   p.reset();
-  EXPECT_EQ(D::count, 1);
   EXPECT_FALSE(p);
+  EXPECT_EQ(D::count, 1);
 }
-int D::count = 0;


### PR DESCRIPTION
This UniquePtr implementation integrates with radiant's allocator system and provides standard smart pointer semantics with move-only ownership, customizable deleters, and automatic resource cleanup. The implementation uses EmptyOptimizedPair to achieve zero storage overhead for empty deleters (sizeof(UniquePtr<T>) == sizeof(T*)). It supports type-safe conversions for inheritance hierarchies and integrates with AllocTraits for allocator-aware construction through two make_unique overloads: standard (new/delete) and allocator-aware.

The implementation follows radiant conventions, using Get() instead of get(), avoiding std:: dependencies, and integrating with the existing AllocTraits system. AllocatorDeleter provides automatic cleanup for allocator-constructed objects.

Comprehensive tests cover basic functionality, move semantics, custom deleters, type conversions, allocator integration, and edge cases including allocation failures.